### PR TITLE
fix(frontend): remove duplicate spinner on Google sign-in button

### DIFF
--- a/frontend/app/login.tsx
+++ b/frontend/app/login.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, View } from 'react-native';
-import { ActivityIndicator, Button, Text, useTheme } from 'react-native-paper';
+import { Button, Text, useTheme } from 'react-native-paper';
 import { useAuth } from '../hooks/useAuth';
 import { spacing } from '../config/theme';
 
@@ -26,8 +26,6 @@ export default function LoginScreen() {
       >
         Sign in with Google
       </Button>
-
-      {isSigningIn && <ActivityIndicator style={styles.spinner} />}
 
       {error && (
         <Text variant="bodySmall" style={[styles.error, { color: theme.colors.error }]}>
@@ -56,9 +54,6 @@ const styles = StyleSheet.create({
   },
   button: {
     width: '100%',
-  },
-  spinner: {
-    marginTop: spacing.lg,
   },
   error: {
     marginTop: spacing.lg,


### PR DESCRIPTION
## Summary
- The Google sign-in button's built-in `loading` prop already renders a spinner in place; a separate standalone `ActivityIndicator` below it was also gated on `isSigningIn`, showing two spinners at once during sign-in.
- Removed the duplicate indicator so only the button shows the loading spinner.

Fixes #33

## Test plan
- [x] Verified `login.tsx` only renders one loading spinner (the button's built-in one) when `isSigningIn` is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)