### PR TITLE
Give pending-invites bell its own accept/reject dropdown

### DIFF
--- a/frontend/app/account-access.tsx
+++ b/frontend/app/account-access.tsx
@@ -12,13 +12,10 @@ import {
 } from "react-native-paper";
 import { spacing } from "../config/theme";
 import {
-  useAcceptInvite,
   useCreateInvite,
   useGrantedByMe,
   useGrantedToMe,
   useLeaveAccess,
-  usePendingInvites,
-  useRejectInvite,
   useRevokeAccess
 } from "../hooks/useAccountAccess";
 import { AccessRole, AccessStatus, AccountAccess } from "../types/accountAccess";
@@ -34,12 +31,9 @@ function SectionTitle({ children }: { children: string }) {
 export default function AccountAccessScreen() {
   const theme = useTheme();
 
-  const { data: pending, isLoading: isPendingLoading } = usePendingInvites();
   const { data: grantedToMe, isLoading: isGrantedToMeLoading } = useGrantedToMe();
   const { data: grantedByMe, isLoading: isGrantedByMeLoading } = useGrantedByMe();
 
-  const acceptMutation = useAcceptInvite();
-  const rejectMutation = useRejectInvite();
   const leaveMutation = useLeaveAccess();
   const revokeMutation = useRevokeAccess();
   const createInviteMutation = useCreateInvite();
@@ -67,39 +61,6 @@ export default function AccountAccessScreen() {
 
   return (
     <ScrollView style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <SectionTitle>Pending requests</SectionTitle>
-      {isPendingLoading ? (
-        <ActivityIndicator style={styles.loader} />
-      ) : (pending ?? []).length === 0 ? (
-        <Text style={styles.emptyText}>No pending invites</Text>
-      ) : (
-        (pending ?? []).map((grant) => (
-          <View key={grant.id} style={styles.row}>
-            <View style={styles.rowInfo}>
-              <Text variant="bodyLarge">{grant.ownerName ?? grant.owner}</Text>
-              <Text variant="bodySmall" style={styles.rowSubtext}>{grant.role}</Text>
-            </View>
-            <Button
-              mode="text"
-              onPress={() => acceptMutation.mutate(grant.id)}
-              loading={acceptMutation.isPending}
-            >
-              Accept
-            </Button>
-            <Button
-              mode="text"
-              textColor={theme.colors.error}
-              onPress={() => rejectMutation.mutate(grant.id)}
-              loading={rejectMutation.isPending}
-            >
-              Reject
-            </Button>
-          </View>
-        ))
-      )}
-
-      <Divider style={styles.divider} />
-
       <SectionTitle>Shared with me</SectionTitle>
       {isGrantedToMeLoading ? (
         <ActivityIndicator style={styles.loader} />

--- a/frontend/components/PendingInvitesBell.tsx
+++ b/frontend/components/PendingInvitesBell.tsx
@@ -1,22 +1,75 @@
-import { useRouter } from 'expo-router';
-import React from 'react';
-import { View } from 'react-native';
-import { Badge, IconButton } from 'react-native-paper';
-import { usePendingInvites } from '../hooks/useAccountAccess';
+import React, { useState } from 'react';
+import { ScrollView, View } from 'react-native';
+import { Badge, Button, Divider, IconButton, Menu, Text, useTheme } from 'react-native-paper';
+import { spacing } from '../config/theme';
+import { useAcceptInvite, usePendingInvites, useRejectInvite } from '../hooks/useAccountAccess';
 
 export default function PendingInvitesBell() {
-  const router = useRouter();
+  const theme = useTheme();
+  const [visible, setVisible] = useState(false);
   const { data: pending } = usePendingInvites();
-  const count = pending?.length ?? 0;
+  const acceptMutation = useAcceptInvite();
+  const rejectMutation = useRejectInvite();
+
+  const invites = pending ?? [];
+  const count = invites.length;
 
   return (
-    <View>
-      <IconButton icon="bell-outline" onPress={() => router.push('/account-access')} />
-      {count > 0 && (
-        <Badge size={16} style={{ position: 'absolute', top: 4, right: 4 }}>
-          {count}
-        </Badge>
+    <Menu
+      visible={visible}
+      onDismiss={() => setVisible(false)}
+      anchor={
+        <View>
+          <IconButton icon="bell-outline" onPress={() => setVisible(true)} />
+          {count > 0 && (
+            <Badge size={16} style={{ position: 'absolute', top: 4, right: 4 }}>
+              {count}
+            </Badge>
+          )}
+        </View>
+      }
+      contentStyle={{ minWidth: 280, maxWidth: 320 }}
+    >
+      <Text variant="titleSmall" style={{ paddingHorizontal: spacing.md, paddingVertical: spacing.sm }}>
+        Pending invites
+      </Text>
+      <Divider />
+      {count === 0 ? (
+        <Text style={{ padding: spacing.md, color: theme.colors.onSurfaceVariant }}>
+          No pending invites
+        </Text>
+      ) : (
+        <ScrollView style={{ maxHeight: 320 }}>
+          {invites.map((grant) => (
+            <View key={grant.id} style={{ paddingHorizontal: spacing.md, paddingVertical: spacing.sm }}>
+              <Text variant="bodyMedium">{grant.ownerName ?? grant.owner}</Text>
+              <Text
+                variant="bodySmall"
+                style={{ color: theme.colors.onSurfaceVariant, marginBottom: spacing.xs }}
+              >
+                {grant.role}
+              </Text>
+              <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
+                <Button
+                  mode="text"
+                  onPress={() => acceptMutation.mutate(grant.id)}
+                  loading={acceptMutation.isPending && acceptMutation.variables === grant.id}
+                >
+                  Accept
+                </Button>
+                <Button
+                  mode="text"
+                  textColor={theme.colors.error}
+                  onPress={() => rejectMutation.mutate(grant.id)}
+                  loading={rejectMutation.isPending && rejectMutation.variables === grant.id}
+                >
+                  Reject
+                </Button>
+              </View>
+            </View>
+          ))}
+        </ScrollView>
       )}
-    </View>
+    </Menu>
   );
 }


### PR DESCRIPTION
## Summary
- The header bell and the avatar's Manage Access item both navigated to the same /account-access screen -- confusing duplicate entry points.
- Bell now opens a dropdown listing pending invites with inline Accept/Reject, no navigation.
- Manage Access page drops the now-redundant Pending requests section; it's reached via avatar -> Manage Access and covers Shared with me / People I've shared with.

Closes #35

## Test plan
- [x] npx tsc --noEmit (frontend) -- clean
- [x] npm run lint (frontend) -- no errors
- [ ] Manual click-through on device/simulator (not available in this environment)