### PR TITLE
fix(frontend): give bell and avatar menus a shared exclusive open state

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -2,6 +2,7 @@ import { DrawerContentScrollView } from "@react-navigation/drawer";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { usePathname, useRouter } from "expo-router";
 import { Drawer } from "expo-router/drawer";
+import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { ActivityIndicator, Drawer as PaperDrawer, PaperProvider, Text, useTheme } from "react-native-paper";
@@ -13,11 +14,23 @@ import { AccessProvider } from "../contexts/AccessContext";
 import { AuthProvider, useAuthContext } from "../contexts/AuthContext";
 import { UserProvider } from "../contexts/UserContext";
 
+type ActiveMenu = "invites" | "profile" | null;
+
 function HeaderRight() {
+  const [activeMenu, setActiveMenu] = useState<ActiveMenu>(null);
+
   return (
     <View style={{ flexDirection: "row", alignItems: "center" }}>
-      <PendingInvitesBell />
-      <ProfileSwitcherMenu />
+      <PendingInvitesBell
+        visible={activeMenu === "invites"}
+        onOpen={() => setActiveMenu("invites")}
+        onDismiss={() => setActiveMenu((current) => (current === "invites" ? null : current))}
+      />
+      <ProfileSwitcherMenu
+        visible={activeMenu === "profile"}
+        onOpen={() => setActiveMenu("profile")}
+        onDismiss={() => setActiveMenu((current) => (current === "profile" ? null : current))}
+      />
     </View>
   );
 }

--- a/frontend/components/PendingInvitesBell.tsx
+++ b/frontend/components/PendingInvitesBell.tsx
@@ -1,12 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ScrollView, View } from 'react-native';
 import { Badge, Button, Divider, IconButton, Menu, Text, useTheme } from 'react-native-paper';
 import { spacing } from '../config/theme';
 import { useAcceptInvite, usePendingInvites, useRejectInvite } from '../hooks/useAccountAccess';
 
-export default function PendingInvitesBell() {
+interface PendingInvitesBellProps {
+  visible: boolean;
+  onOpen: () => void;
+  onDismiss: () => void;
+}
+
+export default function PendingInvitesBell({ visible, onOpen, onDismiss }: PendingInvitesBellProps) {
   const theme = useTheme();
-  const [visible, setVisible] = useState(false);
   const { data: pending } = usePendingInvites();
   const acceptMutation = useAcceptInvite();
   const rejectMutation = useRejectInvite();
@@ -17,10 +22,10 @@ export default function PendingInvitesBell() {
   return (
     <Menu
       visible={visible}
-      onDismiss={() => setVisible(false)}
+      onDismiss={onDismiss}
       anchor={
         <View>
-          <IconButton icon="bell-outline" onPress={() => setVisible(true)} />
+          <IconButton icon="bell-outline" onPress={onOpen} />
           {count > 0 && (
             <Badge size={16} style={{ position: 'absolute', top: 4, right: 4 }}>
               {count}

--- a/frontend/components/ProfileSwitcherMenu.tsx
+++ b/frontend/components/ProfileSwitcherMenu.tsx
@@ -1,15 +1,20 @@
 import { useRouter } from 'expo-router';
-import React, { useState } from 'react';
+import React from 'react';
 import { Pressable } from 'react-native';
 import { Avatar, Divider, Menu, useTheme } from 'react-native-paper';
 import { useAccessContext } from '../contexts/AccessContext';
 
 const initialsFor = (label: string) => label.trim().charAt(0).toUpperCase() || '?';
 
-export default function ProfileSwitcherMenu() {
+interface ProfileSwitcherMenuProps {
+  visible: boolean;
+  onOpen: () => void;
+  onDismiss: () => void;
+}
+
+export default function ProfileSwitcherMenu({ visible, onOpen, onDismiss }: ProfileSwitcherMenuProps) {
   const router = useRouter();
   const theme = useTheme();
-  const [visible, setVisible] = useState(false);
   const { delegatedOwner, isDelegated, myProfiles, setDelegatedOwner } = useAccessContext();
 
   const activeLabel = myProfiles.find((profile) => profile.owner === delegatedOwner)?.label ?? 'My Account';
@@ -17,9 +22,9 @@ export default function ProfileSwitcherMenu() {
   return (
     <Menu
       visible={visible}
-      onDismiss={() => setVisible(false)}
+      onDismiss={onDismiss}
       anchor={
-        <Pressable onPress={() => setVisible(true)} style={{ marginRight: 12 }}>
+        <Pressable onPress={onOpen} style={{ marginRight: 12 }}>
           <Avatar.Text
             size={32}
             label={initialsFor(activeLabel)}
@@ -37,7 +42,7 @@ export default function ProfileSwitcherMenu() {
           title={profile.owner === delegatedOwner ? `✓ ${profile.label}` : profile.label}
           onPress={() => {
             setDelegatedOwner(profile.owner);
-            setVisible(false);
+            onDismiss();
           }}
         />
       ))}
@@ -45,7 +50,7 @@ export default function ProfileSwitcherMenu() {
       <Menu.Item
         title="Manage Access"
         onPress={() => {
-          setVisible(false);
+          onDismiss();
           router.push('/account-access');
         }}
       />


### PR DESCRIPTION
## Summary
- Lift a single `activeMenu` state into `HeaderRight` (frontend/app/_layout.tsx) so only one of `PendingInvitesBell` / `ProfileSwitcherMenu` can be visible at a time.
- Convert both components' internal `useState` visibility to controlled `visible`/`onOpen`/`onDismiss` props.
- Fixes react-native-paper's shared Portal backdrop swallowing the first tap when switching between the two menus.

Fixes #41

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes with 0 errors (only pre-existing warnings unrelated to these files)
- [ ] Manual verification in the app: tapping the avatar while the bell menu is open opens the avatar menu directly (no double-tap needed), and vice versa