### PR TITLE
fix(frontend): key owner-scoped queries by delegated owner instead of clearing cache

### DIFF
--- a/frontend/app/planned-payments.tsx
+++ b/frontend/app/planned-payments.tsx
@@ -7,7 +7,6 @@ import PlannedPaymentFormModal from "../components/planned-payments/PlannedPayme
 import PlannedPaymentItem from "../components/planned-payments/PlannedPaymentItem";
 import { spacing } from "../config/theme";
 import { useAccessContext } from "../contexts/AccessContext";
-import { useUser } from "../contexts/UserContext";
 import {
   useConfirmPlannedPayment,
   useDeletePlannedPayment,
@@ -19,9 +18,8 @@ import { PlannedPayment } from "../types/plannedPayment";
 
 export default function PlannedPayments() {
   const theme = useTheme();
-  const { user } = useUser();
   const isFocused = useIsFocused();
-  const { activeRole } = useAccessContext();
+  const { activeRole, delegatedOwner } = useAccessContext();
   const isReadOnly = activeRole === AccessRole.READ;
 
   const [isFormModalVisible, setFormModalVisible] = useState(false);
@@ -31,10 +29,11 @@ export default function PlannedPayments() {
   const {
     data: plannedPayments,
     isLoading,
+    isFetching,
     isError,
     error,
     refetch,
-  } = usePlannedPayments(user?.owner || '');
+  } = usePlannedPayments(delegatedOwner);
 
   const deleteMutation = useDeletePlannedPayment();
   const confirmMutation = useConfirmPlannedPayment();
@@ -130,6 +129,11 @@ export default function PlannedPayments() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      {isFetching && (
+        <View style={styles.refreshBar}>
+          <ActivityIndicator size="small" />
+        </View>
+      )}
       <FlatList
         data={plannedPayments}
         renderItem={renderItem}
@@ -233,5 +237,9 @@ const styles = StyleSheet.create({
   },
   emptyList: {
     flex: 1,
+  },
+  refreshBar: {
+    alignItems: "center",
+    paddingVertical: spacing.sm,
   },
 });

--- a/frontend/app/records.tsx
+++ b/frontend/app/records.tsx
@@ -56,19 +56,20 @@ export default function Records() {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [clickedTransaction, setClickedTransaction] = useState<CreateTransactionRequest>();
   const isFocused = useIsFocused();
-  const { activeRole } = useAccessContext();
+  const { activeRole, delegatedOwner } = useAccessContext();
   const isReadOnly = activeRole === AccessRole.READ;
 
   const {
     data,
     isLoading,
+    isFetching,
     isError,
     error,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
     refetch,
-  } = useTransactions({ pageSize: PAGE_SIZE, enabled: isFocused });
+  } = useTransactions({ pageSize: PAGE_SIZE, enabled: isFocused, owner: delegatedOwner });
 
   const deleteTransactionMutation = useDeleteTransaction();
 
@@ -180,6 +181,11 @@ export default function Records() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      {isFetching && !isFetchingNextPage && (
+        <View style={styles.refreshBar}>
+          <ActivityIndicator size="small" />
+        </View>
+      )}
       <FlatList
         data={flatData}
         renderItem={renderItem}
@@ -258,5 +264,9 @@ const styles = StyleSheet.create({
   },
   emptyList: {
     flex: 1,
+  },
+  refreshBar: {
+    alignItems: "center",
+    paddingVertical: spacing.sm,
   },
 });

--- a/frontend/components/BalanceTrendWidget.tsx
+++ b/frontend/components/BalanceTrendWidget.tsx
@@ -3,8 +3,9 @@ import { Dimensions, StyleSheet, View } from 'react-native';
 import { LineChart } from 'react-native-gifted-charts';
 import { ActivityIndicator, Card, Divider, IconButton, Menu, Text, useTheme } from 'react-native-paper';
 import { customTheme, spacing } from '../config/theme';
-import { useUser } from '../contexts/UserContext';
+import { useAccessContext } from '../contexts/AccessContext';
 import { useBalanceTrend } from '../hooks/useBalanceTrend';
+import { useActiveUser } from '../hooks/useUsers';
 import { TrendPeriod } from '../types/balanceTrend';
 
 const PERIOD_OPTIONS = [
@@ -20,27 +21,33 @@ const getPeriodLabel = (period: TrendPeriod): string => {
 
 export const BalanceTrendWidget: React.FC = () => {
   const theme = useTheme();
-  const { user, isLoading: isUserLoading } = useUser();
+  const { delegatedOwner } = useAccessContext();
+  const { data: user, isLoading: isUserLoading } = useActiveUser(delegatedOwner);
 
   const [selectedPeriod, setSelectedPeriod] = useState<TrendPeriod>(TrendPeriod.FROM_START);
-  const [selectedAccounts, setSelectedAccounts] = useState<string[]>(user?.accounts || []);
+  const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
   const [menuVisible, setMenuVisible] = useState(false);
 
-  // Update selected accounts when user data loads
+  // Reset the account filter whenever the active profile changes, then
+  // repopulate it from that profile's own accounts once they load.
+  React.useEffect(() => {
+    setSelectedAccounts([]);
+  }, [delegatedOwner]);
+
   React.useEffect(() => {
     if (user?.accounts && selectedAccounts.length === 0) {
       setSelectedAccounts(user.accounts);
     }
   }, [user?.accounts]);
 
-  const { data, isLoading, isError, error } = useBalanceTrend(
+  const { data, isLoading, isFetching, isError, error } = useBalanceTrend(
     {
-      owner: user?.owner || '',
+      owner: delegatedOwner,
       accounts: selectedAccounts,
       period: selectedPeriod,
     },
     {
-      enabled: !!user?.owner && selectedAccounts.length > 0,
+      enabled: !!delegatedOwner && selectedAccounts.length > 0,
     }
   );
 
@@ -119,9 +126,12 @@ export const BalanceTrendWidget: React.FC = () => {
       <Card.Content>
         {/* Header with Period Menu */}
         <View style={styles.header}>
-          <Text variant="titleLarge" style={styles.title}>
-            Balance Trend
-          </Text>
+          <View style={styles.titleRow}>
+            <Text variant="titleLarge" style={styles.title}>
+              Balance Trend
+            </Text>
+            {isFetching && <ActivityIndicator size="small" style={styles.titleSpinner} />}
+          </View>
           <Menu
             visible={menuVisible}
             onDismiss={() => setMenuVisible(false)}
@@ -244,6 +254,13 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: '600',
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  titleSpinner: {
+    marginLeft: spacing.sm,
   },
   menuButton: {
     margin: 0,

--- a/frontend/components/ExpenseDistributionWidget.tsx
+++ b/frontend/components/ExpenseDistributionWidget.tsx
@@ -3,8 +3,9 @@ import { StyleSheet, View } from 'react-native';
 import { PieChart } from 'react-native-gifted-charts';
 import { ActivityIndicator, Card, Divider, IconButton, Menu, Text, useTheme } from 'react-native-paper';
 import { customColors, customTheme, spacing } from '../config/theme';
-import { useUser } from '../contexts/UserContext';
+import { useAccessContext } from '../contexts/AccessContext';
 import { useExpenseDistribution, useTopContributors } from '../hooks/useExpenseDistribution';
+import { useActiveUser } from '../hooks/useUsers';
 import { TrendPeriod } from '../types/balanceTrend';
 import { Category } from '../types/category';
 import { TopContributorsList } from './TopContributorsList';
@@ -43,43 +44,51 @@ const getCategoryColor = (category: string): string => {
 
 export const ExpenseDistributionWidget: React.FC = () => {
   const theme = useTheme();
-  const { user, isLoading: isUserLoading } = useUser();
+  const { delegatedOwner } = useAccessContext();
+  const { data: user, isLoading: isUserLoading } = useActiveUser(delegatedOwner);
 
   const [selectedPeriod, setSelectedPeriod] = useState<TrendPeriod>(TrendPeriod.LAST_12_WEEKS);
-  const [selectedAccounts, setSelectedAccounts] = useState<string[]>(user?.accounts || []);
+  const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
   const [menuVisible, setMenuVisible] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState<number>(0);
   // Initialize with first category expanded (will be set when data loads)
   const [expandedCategory, setExpandedCategory] = useState<string | null>(null);
   const [initialLoadDone, setInitialLoadDone] = useState(false);
 
-  // Update selected accounts when user data loads
+  // Reset the account filter and expanded category whenever the active
+  // profile changes, then repopulate accounts from that profile's own list.
+  React.useEffect(() => {
+    setSelectedAccounts([]);
+    setExpandedCategory(null);
+    setInitialLoadDone(false);
+  }, [delegatedOwner]);
+
   React.useEffect(() => {
     if (user?.accounts && selectedAccounts.length === 0) {
       setSelectedAccounts(user.accounts);
     }
   }, [user?.accounts]);
 
-  const { data, isLoading, isError, error } = useExpenseDistribution(
+  const { data, isLoading, isFetching, isError, error } = useExpenseDistribution(
     {
-      owner: user?.owner || '',
+      owner: delegatedOwner,
       accounts: selectedAccounts,
       period: selectedPeriod,
     },
     {
-      enabled: !!user?.owner && selectedAccounts.length > 0,
+      enabled: !!delegatedOwner && selectedAccounts.length > 0,
     }
   );
 
   // Fetch contributors when a category is expanded
   const { data: contributorsData, isLoading: isContributorsLoading } = useTopContributors(
     {
-      owner: user?.owner || '',
+      owner: delegatedOwner,
       category: expandedCategory || '',
       period: selectedPeriod,
     },
     {
-      enabled: !!user?.owner && !!expandedCategory,
+      enabled: !!delegatedOwner && !!expandedCategory,
     }
   );
 
@@ -144,9 +153,12 @@ export const ExpenseDistributionWidget: React.FC = () => {
       <Card.Content>
         {/* Header with Period Menu */}
         <View style={styles.header}>
-          <Text variant="titleLarge" style={styles.title}>
-            Expense Distribution
-          </Text>
+          <View style={styles.titleRow}>
+            <Text variant="titleLarge" style={styles.title}>
+              Expense Distribution
+            </Text>
+            {isFetching && <ActivityIndicator size="small" style={styles.titleSpinner} />}
+          </View>
           <Menu
             visible={menuVisible}
             onDismiss={() => setMenuVisible(false)}
@@ -287,6 +299,13 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: '600',
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  titleSpinner: {
+    marginLeft: spacing.sm,
   },
   menuButton: {
     margin: 0,

--- a/frontend/components/ProfileSwitcherMenu.tsx
+++ b/frontend/components/ProfileSwitcherMenu.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { Pressable } from 'react-native';
-import { Avatar, Divider, Menu, useTheme } from 'react-native-paper';
+import { Pressable, View } from 'react-native';
+import { ActivityIndicator, Avatar, Divider, Menu, useTheme } from 'react-native-paper';
 import { useAccessContext } from '../contexts/AccessContext';
 
 const initialsFor = (label: string) => label.trim().charAt(0).toUpperCase() || '?';
@@ -10,7 +10,7 @@ export default function ProfileSwitcherMenu() {
   const router = useRouter();
   const theme = useTheme();
   const [visible, setVisible] = useState(false);
-  const { delegatedOwner, isDelegated, myProfiles, setDelegatedOwner } = useAccessContext();
+  const { delegatedOwner, isDelegated, isSwitchingAccount, myProfiles, setDelegatedOwner } = useAccessContext();
 
   const activeLabel = myProfiles.find((profile) => profile.owner === delegatedOwner)?.label ?? 'My Account';
 
@@ -20,14 +20,32 @@ export default function ProfileSwitcherMenu() {
       onDismiss={() => setVisible(false)}
       anchor={
         <Pressable onPress={() => setVisible(true)} style={{ marginRight: 12 }}>
-          <Avatar.Text
-            size={32}
-            label={initialsFor(activeLabel)}
-            style={{
-              backgroundColor: isDelegated ? theme.colors.tertiaryContainer : theme.colors.primaryContainer,
-            }}
-            color={isDelegated ? theme.colors.onTertiaryContainer : theme.colors.onPrimaryContainer}
-          />
+          {isSwitchingAccount ? (
+            <View
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 16,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: isDelegated ? theme.colors.tertiaryContainer : theme.colors.primaryContainer,
+              }}
+            >
+              <ActivityIndicator
+                size="small"
+                color={isDelegated ? theme.colors.onTertiaryContainer : theme.colors.onPrimaryContainer}
+              />
+            </View>
+          ) : (
+            <Avatar.Text
+              size={32}
+              label={initialsFor(activeLabel)}
+              style={{
+                backgroundColor: isDelegated ? theme.colors.tertiaryContainer : theme.colors.primaryContainer,
+              }}
+              color={isDelegated ? theme.colors.onTertiaryContainer : theme.colors.onPrimaryContainer}
+            />
+          )}
         </Pressable>
       }
     >
@@ -35,6 +53,7 @@ export default function ProfileSwitcherMenu() {
         <Menu.Item
           key={profile.owner}
           title={profile.owner === delegatedOwner ? `✓ ${profile.label}` : profile.label}
+          disabled={isSwitchingAccount}
           onPress={() => {
             setDelegatedOwner(profile.owner);
             setVisible(false);

--- a/frontend/components/TransactionFormModal.tsx
+++ b/frontend/components/TransactionFormModal.tsx
@@ -10,8 +10,9 @@ import {
 import { Button, Chip, Divider, IconButton, SegmentedButtons, Surface, Text, TextInput, useTheme } from 'react-native-paper';
 import { TimePickerModal } from 'react-native-paper-dates';
 import { shadows, spacing } from '../config/theme';
-import { useUser } from '../contexts/UserContext';
+import { useAccessContext } from '../contexts/AccessContext';
 import { useCreateTransaction, useDistinctNotes, useUpdateTransaction } from '../hooks/useTransactions';
+import { useActiveUser } from '../hooks/useUsers';
 import { CreateTransactionRequest } from '../services/transaction.service';
 import { Category } from '../types/category';
 import { TransactionType } from '../types/transaction';
@@ -26,11 +27,12 @@ interface TransactionFormModalProps {
 }
 
 const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, onClose, initialData }) => {
-  const { user } = useUser();
+  const { delegatedOwner } = useAccessContext();
+  const { data: user } = useActiveUser(delegatedOwner);
   const theme = useTheme();
   const { mutate: createTransaction, isPending: isCreating } = useCreateTransaction();
   const { mutate: updateTransaction, isPending: isUpdating } = useUpdateTransaction();
-  const { data: distinctNotes } = useDistinctNotes(user!.owner);
+  const { data: distinctNotes } = useDistinctNotes(delegatedOwner);
 
   const isPending = isCreating || isUpdating;
   const isEditMode = !!initialData?.id;

--- a/frontend/components/planned-payments/PlannedPaymentFormModal.tsx
+++ b/frontend/components/planned-payments/PlannedPaymentFormModal.tsx
@@ -9,9 +9,10 @@ import {
 } from 'react-native';
 import { Button, Checkbox, Chip, Divider, IconButton, SegmentedButtons, Surface, Text, TextInput, useTheme } from 'react-native-paper';
 import { shadows, spacing } from '../../config/theme';
-import { useUser } from '../../contexts/UserContext';
+import { useAccessContext } from '../../contexts/AccessContext';
 import { useCreatePlannedPayment, useUpdatePlannedPayment } from '../../hooks/usePlannedPayments';
 import { useDistinctNotes } from '../../hooks/useTransactions';
+import { useActiveUser } from '../../hooks/useUsers';
 import { Category } from '../../types/category';
 import { ConfirmationType, CreatePlannedPaymentRequest, EndType, PlannedPayment, RecurrenceType } from '../../types/plannedPayment';
 import { getCategoryIcon } from '../../utils/categoryIcons';
@@ -25,11 +26,12 @@ interface PlannedPaymentFormModalProps {
 }
 
 const PlannedPaymentFormModal: React.FC<PlannedPaymentFormModalProps> = ({ visible, onClose, initialData }) => {
-  const { user } = useUser();
+  const { delegatedOwner } = useAccessContext();
+  const { data: user } = useActiveUser(delegatedOwner);
   const theme = useTheme();
   const { mutate: createPlannedPayment, isPending: isCreating } = useCreatePlannedPayment();
   const { mutate: updatePlannedPayment, isPending: isUpdating } = useUpdatePlannedPayment();
-  const { data: distinctNotes } = useDistinctNotes(user!.owner);
+  const { data: distinctNotes } = useDistinctNotes(delegatedOwner);
 
   const isPending = isCreating || isUpdating;
   const isEditMode = !!initialData;

--- a/frontend/contexts/AccessContext.tsx
+++ b/frontend/contexts/AccessContext.tsx
@@ -6,7 +6,6 @@ import {
   getStoredDelegatedOwner,
   setStoredDelegatedOwner
 } from '../config/delegatedOwnerStorage';
-import { queryClient } from '../config/queryClient';
 import { AccessRole, AccessStatus } from '../types/accountAccess';
 import { useGrantedToMe } from '../hooks/useAccountAccess';
 import { useUser } from './UserContext';
@@ -21,6 +20,7 @@ export interface DelegatedProfile {
 interface AccessContextType {
   delegatedOwner: string;
   isDelegated: boolean;
+  isSwitchingAccount: boolean;
   activeRole: AccessRole | null;
   myProfiles: DelegatedProfile[];
   setDelegatedOwner: (owner: string) => void;
@@ -36,6 +36,7 @@ export const AccessProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [delegatedOwner, setDelegatedOwnerState] = useState('');
   const [hasLoadedPersisted, setHasLoadedPersisted] = useState(false);
   const [revokedMessage, setRevokedMessage] = useState<string | null>(null);
+  const [isSwitchingAccount, setIsSwitchingAccount] = useState(false);
 
   const myProfiles: DelegatedProfile[] = useMemo(() => {
     if (!selfOwner) return [];
@@ -79,20 +80,21 @@ export const AccessProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     setAccessRevokedHandler(() => {
       applyDelegatedOwner(selfOwner);
       clearStoredDelegatedOwner();
-      queryClient.clear();
       setRevokedMessage('Access to this account was removed');
     });
     return () => setAccessRevokedHandler(null);
   }, [selfOwner]);
 
+  // Every owner-scoped query is keyed by the active owner (see useActiveUser,
+  // useTransactions, useBalanceTrend, etc.), so switching profiles naturally
+  // triggers a refetch under the new key - no manual cache invalidation
+  // needed. isSwitchingAccount just gives the switcher UI something to show
+  // for the brief window before that refetch kicks in.
   const setDelegatedOwner = (owner: string) => {
+    setIsSwitchingAccount(true);
     applyDelegatedOwner(owner);
-    if (owner === selfOwner) {
-      clearStoredDelegatedOwner();
-    } else {
-      setStoredDelegatedOwner(owner);
-    }
-    queryClient.clear();
+    const persisted = owner === selfOwner ? clearStoredDelegatedOwner() : setStoredDelegatedOwner(owner);
+    persisted.finally(() => setIsSwitchingAccount(false));
   };
 
   const activeRole = myProfiles.find((profile) => profile.owner === delegatedOwner)?.role ?? null;
@@ -100,6 +102,7 @@ export const AccessProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const value: AccessContextType = {
     delegatedOwner: delegatedOwner || selfOwner,
     isDelegated: !!delegatedOwner && delegatedOwner !== selfOwner,
+    isSwitchingAccount,
     activeRole,
     myProfiles,
     setDelegatedOwner,

--- a/frontend/hooks/useTransactions.ts
+++ b/frontend/hooks/useTransactions.ts
@@ -7,23 +7,24 @@ import { BALANCE_TREND_QUERY_KEYS } from './useBalanceTrend';
 export const TRANSACTION_QUERY_KEYS = {
   all: ['transactions'] as const,
   lists: () => [...TRANSACTION_QUERY_KEYS.all, 'list'] as const,
-  list: (params?: GetTransactionsParams) => [...TRANSACTION_QUERY_KEYS.lists(), params] as const,
+  list: (owner: string, params?: GetTransactionsParams) => [...TRANSACTION_QUERY_KEYS.lists(), owner, params] as const,
 };
 
 interface UseTransactionsOptions {
   pageSize?: number;
   enabled?: boolean;
+  owner: string;
 }
 
-export const useTransactions = (options: UseTransactionsOptions = {}) => {
-  const { pageSize, enabled = true } = options;
+export const useTransactions = (options: UseTransactionsOptions) => {
+  const { pageSize, enabled = true, owner } = options;
 
   return useInfiniteQuery({
-    queryKey: TRANSACTION_QUERY_KEYS.list({ size: pageSize }),
+    queryKey: TRANSACTION_QUERY_KEYS.list(owner, { size: pageSize }),
     queryFn: ({ pageParam }) => getAllTransactions({ page: pageParam as number, size: pageSize }),
     initialPageParam: 0,
     getNextPageParam: (lastPage: PageResponse<Transaction>) => lastPage.hasNext ? lastPage.pageNumber + 1 : null,
-    enabled
+    enabled: enabled && !!owner,
   });
 };
 
@@ -89,8 +90,9 @@ export const useUpdateTransaction = () => {
 
 export const useDistinctNotes = (owner: string) => {
   return useQuery({
-    queryKey: ["notes"],
-    queryFn: () => getDistinctNotes(owner)
+    queryKey: ["notes", owner],
+    queryFn: () => getDistinctNotes(owner),
+    enabled: !!owner,
   })
 }
 

--- a/frontend/hooks/useUsers.ts
+++ b/frontend/hooks/useUsers.ts
@@ -9,6 +9,20 @@ export const useCurrentUser = () => useQuery({
   queryFn: () => getCurrentUser()
 });
 
+// Distinct from useCurrentUser: this reflects whichever profile is currently
+// active (self or a delegated owner), keyed by that owner so switching
+// profiles naturally triggers a refetch instead of silently keeping self's
+// cached record. getCurrentUser() resolves server-side via the
+// X-Delegated-Owner header (see config/api.ts), so passing the active owner
+// through the query key is enough - no explicit invalidation needed.
+export const ACTIVE_USER_QUERY_KEY = (owner: string) => ['users', 'active', owner] as const;
+
+export const useActiveUser = (owner: string) => useQuery({
+  queryKey: ACTIVE_USER_QUERY_KEY(owner),
+  queryFn: () => getCurrentUser(),
+  enabled: !!owner,
+});
+
 export const useCreateUser = () => useMutation({
   mutationFn: (userData: Omit<User, 'id'>) => createUser(userData)
 });;


### PR DESCRIPTION
## Summary
- Switching profiles via the avatar menu no longer relies on `queryClient.clear()`, which doesn't force already-mounted widgets to refetch — instead owner-scoped queries (`useActiveUser`, transactions, planned payments, balance trend, expense distribution) are keyed by `delegatedOwner` so they refetch naturally on switch.
- `BalanceTrendWidget`, `ExpenseDistributionWidget`, `TransactionFormModal`, and `PlannedPaymentFormModal` now read the active delegated profile's data/accounts instead of self's.
- Added an `isSwitchingAccount` spinner on the profile switcher avatar, plus `isFetching` indicators on Records and Planned Payments during background refetches.

Fixes #42

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx expo lint` — 0 errors (only pre-existing warnings)
- [ ] Manually switch delegated accounts in the app and confirm Dashboard/Records/Planned Payments update without a manual refresh