### PR TITLE
Fix dashboard total-header noise and backfill default accounts for existing users

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "worktree": {
+    "bgIsolation": "worktree"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/backend/src/main/java/com/lazyspender/backend/migration/BackfillDefaultAccountsForExistingUsers.java
+++ b/backend/src/main/java/com/lazyspender/backend/migration/BackfillDefaultAccountsForExistingUsers.java
@@ -1,0 +1,49 @@
+package com.lazyspender.backend.migration;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import com.lazyspender.backend.model.User;
+import com.lazyspender.backend.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * One-off bootstrap: {@link BackfillUserAccountsMigration} only backfills the
+ * currently authenticated principal via POST /api/backfill/user-accounts, so
+ * users created before default accounts existed (see AuthService) stay stuck
+ * without any accounts unless they happen to call that endpoint themselves.
+ *
+ * Runs on every app boot but is idempotent: BackfillUserAccountsMigration
+ * already skips any user that already has accounts.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BackfillDefaultAccountsForExistingUsers implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+    private final BackfillUserAccountsMigration backfillUserAccountsMigration;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            backfillAll();
+        } catch (Exception e) {
+            log.error("Failed to backfill default accounts for existing users", e);
+        }
+    }
+
+    private void backfillAll() {
+        int backfilled = 0;
+        for (User user : userRepository.findAll()) {
+            if (user.getAccounts() == null || user.getAccounts().isEmpty()) {
+                backfillUserAccountsMigration.backfillAccounts(user.getOwner());
+                backfilled++;
+            }
+        }
+        log.info("Default accounts backfill complete: {} user(s) updated", backfilled);
+    }
+}

--- a/frontend/components/BalanceTrendWidget.tsx
+++ b/frontend/components/BalanceTrendWidget.tsx
@@ -166,14 +166,16 @@ export const BalanceTrendWidget: React.FC = () => {
         </Text>
 
         {/* Total Balance */}
-        <View style={styles.balanceContainer}>
-          <Text variant="headlineLarge" style={styles.balanceAmount}>
-            {data?.currency || 'PHP'} {data?.totalBalance.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-          </Text>
-          <Text variant="bodySmall" style={styles.balanceLabel}>
-            Total Balance
-          </Text>
-        </View>
+        {chartData.length > 0 && (
+          <View style={styles.balanceContainer}>
+            <Text variant="headlineLarge" style={styles.balanceAmount}>
+              {data?.currency || 'PHP'} {data?.totalBalance.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </Text>
+            <Text variant="bodySmall" style={styles.balanceLabel}>
+              Total Balance
+            </Text>
+          </View>
+        )}
 
         {/* Line Chart */}
         {chartData.length > 0 ? (

--- a/frontend/components/ExpenseDistributionWidget.tsx
+++ b/frontend/components/ExpenseDistributionWidget.tsx
@@ -194,14 +194,16 @@ export const ExpenseDistributionWidget: React.FC = () => {
         </Text>
 
         {/* Total Expense */}
-        <View style={styles.totalContainer}>
-          <Text variant="headlineLarge" style={styles.totalAmount}>
-            {data?.currency || 'PHP'} {data?.totalExpense.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-          </Text>
-          <Text variant="bodySmall" style={styles.totalLabel}>
-            Total Expenses
-          </Text>
-        </View>
+        {pieData.length > 0 && (
+          <View style={styles.totalContainer}>
+            <Text variant="headlineLarge" style={styles.totalAmount}>
+              {data?.currency || 'PHP'} {data?.totalExpense.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </Text>
+            <Text variant="bodySmall" style={styles.totalLabel}>
+              Total Expenses
+            </Text>
+          </View>
+        )}
 
         {/* Pie Chart */}
         {pieData.length > 0 ? (


### PR DESCRIPTION
## Summary
- Hide the "PHP 0.00 / Total Balance" and "PHP 0.00 / Total Expenses" header row on the dashboard widgets when there's no transaction history yet, instead of showing a zeroed-out total as noise.
- Add a one-off, idempotent startup migration (`BackfillDefaultAccountsForExistingUsers`) that backfills default `["Savings", "Crypto"]` accounts for any existing user missing them. Default accounts were already added for *new* SSO sign-ins (`AuthService`), and a scoped `/api/backfill/user-accounts` endpoint exists for existing users — but it requires the affected user to be authenticated and manually call it, which nobody had done, so pre-existing users still hit "Add an account to your profile before creating a transaction".
- Set `worktree.bgIsolation: "worktree"` in `.claude/settings.json` so background Claude Code sessions in this repo always isolate into a dedicated git worktree instead of editing the shared checkout directly, per the workflow in CLAUDE.md.

Closes #45

## Test plan
- [x] `./gradlew test` passes in `backend/`
- [x] `./gradlew compileJava` succeeds with the new migration class
- [ ] Manually verify in the running app: a user with zero transactions sees no PHP/Total header on the dashboard, and can create a transaction without the "Add an account" error after the backend redeploys and runs the boot migration