### PR TITLE
fix(frontend): allow tapping Notes autocomplete suggestions without dismissing keyboard first

### DIFF
--- a/frontend/components/TransactionFormModal.tsx
+++ b/frontend/components/TransactionFormModal.tsx
@@ -183,7 +183,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, on
                   <IconButton icon="close" onPress={handleClose} disabled={isPending} />
                 </View>
 
-                <ScrollView style={styles.form} showsVerticalScrollIndicator={false}>
+                <ScrollView style={styles.form} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
                   <View style={styles.inputGroup}>
                     <SegmentedButtons
                       value={formData.type || TransactionType.EXPENSE}

--- a/frontend/components/planned-payments/PlannedPaymentFormModal.tsx
+++ b/frontend/components/planned-payments/PlannedPaymentFormModal.tsx
@@ -182,7 +182,7 @@ const PlannedPaymentFormModal: React.FC<PlannedPaymentFormModalProps> = ({ visib
                   <IconButton icon="close" onPress={handleClose} disabled={isPending} />
                 </View>
 
-                <ScrollView style={styles.form} showsVerticalScrollIndicator={false}>
+                <ScrollView style={styles.form} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
                   <View style={styles.inputGroup}>
                     <SegmentedButtons
                       value={isExpense ? 'expense' : 'income'}


### PR DESCRIPTION
## Summary
- Adds `keyboardShouldPersistTaps="handled"` to the `TransactionFormModal` and `PlannedPaymentFormModal` ScrollViews.
- Fixes the Notes-field autocomplete UX: previously, tapping a suggestion while the keyboard was open just dismissed the keyboard (RN's default `keyboardShouldPersistTaps="never"`) instead of registering the tap, forcing a collapse-then-select workflow.

Closes #48

## Test plan
- [x] `npm run lint` — 0 errors, no new warnings in touched files
- [ ] Manually verify in Expo: open the transaction form, type into Notes, tap a suggestion while the keyboard is still up — it should apply the suggestion on the first tap
- [ ] Repeat for the planned payment form