### PR TITLE
Retire Transportation category: split into 7 dedicated categories

### DIFF
--- a/backend/src/main/java/com/lazyspender/backend/controller/BackfillController.java
+++ b/backend/src/main/java/com/lazyspender/backend/controller/BackfillController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lazyspender.backend.migration.BackfillPlannedPaymentsIdForTransaction;
+import com.lazyspender.backend.migration.BackfillTransportationCategorySplit;
 import com.lazyspender.backend.migration.BackfillUserAccountsMigration;
 
 import lombok.AllArgsConstructor;
@@ -20,6 +21,7 @@ public class BackfillController {
 
     private final BackfillPlannedPaymentsIdForTransaction backfillPlannedPaymentsIdForTransaction;
     private final BackfillUserAccountsMigration backfillUserAccountsMigration;
+    private final BackfillTransportationCategorySplit backfillTransportationCategorySplit;
 
     @PostMapping(path = "/transaction-planned-payments")
     public ResponseEntity<Void> backfillTransactionPlannedPayments(Principal principal) {
@@ -30,6 +32,13 @@ public class BackfillController {
     @PostMapping(path = "/user-accounts")
     public ResponseEntity<Void> backfillUserAccounts(Principal principal) {
         backfillUserAccountsMigration.backfillAccounts(principal.getName());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping(path = "/transportation-category-split")
+    public ResponseEntity<Void> backfillTransportationCategorySplit() {
+        backfillTransportationCategorySplit.backfillTransactions();
+        backfillTransportationCategorySplit.backfillPlannedPayments();
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/backend/src/main/java/com/lazyspender/backend/controller/BackfillController.java
+++ b/backend/src/main/java/com/lazyspender/backend/controller/BackfillController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lazyspender.backend.migration.BackfillPlannedPaymentsIdForTransaction;
-import com.lazyspender.backend.migration.BackfillTransportationCategorySplit;
 import com.lazyspender.backend.migration.BackfillUserAccountsMigration;
 
 import lombok.AllArgsConstructor;
@@ -21,7 +20,6 @@ public class BackfillController {
 
     private final BackfillPlannedPaymentsIdForTransaction backfillPlannedPaymentsIdForTransaction;
     private final BackfillUserAccountsMigration backfillUserAccountsMigration;
-    private final BackfillTransportationCategorySplit backfillTransportationCategorySplit;
 
     @PostMapping(path = "/transaction-planned-payments")
     public ResponseEntity<Void> backfillTransactionPlannedPayments(Principal principal) {
@@ -32,13 +30,6 @@ public class BackfillController {
     @PostMapping(path = "/user-accounts")
     public ResponseEntity<Void> backfillUserAccounts(Principal principal) {
         backfillUserAccountsMigration.backfillAccounts(principal.getName());
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
-
-    @PostMapping(path = "/transportation-category-split")
-    public ResponseEntity<Void> backfillTransportationCategorySplit() {
-        backfillTransportationCategorySplit.backfillTransactions();
-        backfillTransportationCategorySplit.backfillPlannedPayments();
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/backend/src/main/java/com/lazyspender/backend/migration/BackfillTransportationCategorySplit.java
+++ b/backend/src/main/java/com/lazyspender/backend/migration/BackfillTransportationCategorySplit.java
@@ -4,7 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.stereotype.Service;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
 import com.lazyspender.backend.model.PlannedPayment;
 import com.lazyspender.backend.model.Transaction;
@@ -17,12 +20,13 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * One-off backfill retiring the "Transportation" category in favor of
  * Parking/Ride-Hailing/Fuel/Toll/Car Maintenance/Car Loan/Incident-Emergencies.
- * See https://github.com/vinzievillamor/lazyspender/issues/51.
+ * Runs once on boot when enabled; see https://github.com/vinzievillamor/lazyspender/issues/51.
  */
-@Service
+@Component
+@ConditionalOnProperty(name = "migration.backfill-transportation-category-split.enabled", havingValue = "true")
 @RequiredArgsConstructor
 @Slf4j
-public class BackfillTransportationCategorySplit {
+public class BackfillTransportationCategorySplit implements ApplicationRunner {
 
     private static final String TRANSPORTATION_CATEGORY = "Transportation";
 
@@ -55,7 +59,13 @@ public class BackfillTransportationCategorySplit {
     private final TransactionRepository transactionRepository;
     private final PlannedPaymentRepository plannedPaymentRepository;
 
-    public void backfillTransactions() {
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        backfillTransactions();
+        backfillPlannedPayments();
+    }
+
+    private void backfillTransactions() {
         log.info("=== Starting Transportation Category Split (Transactions) ===");
 
         List<Transaction> allTransactions = new ArrayList<>();
@@ -87,7 +97,7 @@ public class BackfillTransportationCategorySplit {
                 updated, skippedNoMatch, allTransactions.size());
     }
 
-    public void backfillPlannedPayments() {
+    private void backfillPlannedPayments() {
         log.info("=== Starting Transportation Category Split (Planned Payments) ===");
 
         List<PlannedPayment> allPlannedPayments = new ArrayList<>();

--- a/backend/src/main/java/com/lazyspender/backend/migration/BackfillTransportationCategorySplit.java
+++ b/backend/src/main/java/com/lazyspender/backend/migration/BackfillTransportationCategorySplit.java
@@ -1,0 +1,137 @@
+package com.lazyspender.backend.migration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.lazyspender.backend.model.PlannedPayment;
+import com.lazyspender.backend.model.Transaction;
+import com.lazyspender.backend.repository.PlannedPaymentRepository;
+import com.lazyspender.backend.repository.TransactionRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * One-off backfill retiring the "Transportation" category in favor of
+ * Parking/Ride-Hailing/Fuel/Toll/Car Maintenance/Car Loan/Incident-Emergencies.
+ * See https://github.com/vinzievillamor/lazyspender/issues/51.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BackfillTransportationCategorySplit {
+
+    private static final String TRANSPORTATION_CATEGORY = "Transportation";
+
+    private record CategoryNote(String category, String note) {
+    }
+
+    // Exact-match mapping keyed by the current (lowercased, trimmed) note.
+    private static final Map<String, CategoryNote> NOTE_MAPPING = Map.ofEntries(
+            Map.entry("parking", new CategoryNote("Parking", "parking")),
+            Map.entry("parking incident", new CategoryNote("Incident/Emergencies", "parking incident")),
+            Map.entry("grab", new CategoryNote("Ride-Hailing", "grab")),
+            Map.entry("motor ride app", new CategoryNote("Ride-Hailing", "motor ride app")),
+            Map.entry("from/to sogo", new CategoryNote("Ride-Hailing", "grab")),
+            Map.entry("rachelle to mytown la", new CategoryNote("Ride-Hailing", "grab")),
+            Map.entry("sm makati to rachelle house", new CategoryNote("Ride-Hailing", "grab")),
+            Map.entry("fuel", new CategoryNote("Fuel", "fuel")),
+            Map.entry("car wash", new CategoryNote("Car Maintenance", "car wash")),
+            Map.entry("car pms", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("car scent", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("car maintenance", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("battery", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("blade asia wiper fluid", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("car insurance", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("car registration renewal", new CategoryNote("Car Maintenance", "car maintenance")),
+            Map.entry("car monthly amortization", new CategoryNote("Car Loan", "amortization")),
+            Map.entry("toll", new CategoryNote("Toll", "toll")),
+            Map.entry("autosweep", new CategoryNote("Toll", "toll")),
+            Map.entry("traffic violation", new CategoryNote("Incident/Emergencies", "traffic violation")));
+
+    private final TransactionRepository transactionRepository;
+    private final PlannedPaymentRepository plannedPaymentRepository;
+
+    public void backfillTransactions() {
+        log.info("=== Starting Transportation Category Split (Transactions) ===");
+
+        List<Transaction> allTransactions = new ArrayList<>();
+        transactionRepository.findAll().forEach(allTransactions::add);
+
+        int updated = 0;
+        int skippedNoMatch = 0;
+
+        for (Transaction transaction : allTransactions) {
+            if (!TRANSPORTATION_CATEGORY.equals(transaction.getCategory())) {
+                continue;
+            }
+
+            CategoryNote mapped = resolveMapping(transaction.getNote(), transaction.getAmount());
+            if (mapped == null) {
+                skippedNoMatch++;
+                log.warn("No mapping found for transaction {} (note='{}', amount={})",
+                        transaction.getId(), transaction.getNote(), transaction.getAmount());
+                continue;
+            }
+
+            transaction.setCategory(mapped.category());
+            transaction.setNote(mapped.note());
+            transactionRepository.save(transaction);
+            updated++;
+        }
+
+        log.info("=== Transaction Backfill Complete === updated={} skippedNoMatch={} totalScanned={}",
+                updated, skippedNoMatch, allTransactions.size());
+    }
+
+    public void backfillPlannedPayments() {
+        log.info("=== Starting Transportation Category Split (Planned Payments) ===");
+
+        List<PlannedPayment> allPlannedPayments = new ArrayList<>();
+        plannedPaymentRepository.findAll().forEach(allPlannedPayments::add);
+
+        int updated = 0;
+        int skippedNoMatch = 0;
+
+        for (PlannedPayment plannedPayment : allPlannedPayments) {
+            if (!TRANSPORTATION_CATEGORY.equals(plannedPayment.getCategory())) {
+                continue;
+            }
+
+            CategoryNote mapped = resolveMapping(plannedPayment.getNote(), plannedPayment.getAmount());
+            if (mapped == null) {
+                skippedNoMatch++;
+                log.warn("No mapping found for planned payment {} (note='{}', amount={})",
+                        plannedPayment.getId(), plannedPayment.getNote(), plannedPayment.getAmount());
+                continue;
+            }
+
+            plannedPayment.setCategory(mapped.category());
+            plannedPayment.setNote(mapped.note());
+            plannedPaymentRepository.save(plannedPayment);
+            updated++;
+        }
+
+        log.info("=== Planned Payment Backfill Complete === updated={} skippedNoMatch={} totalScanned={}",
+                updated, skippedNoMatch, allPlannedPayments.size());
+    }
+
+    private CategoryNote resolveMapping(String note, double amount) {
+        String normalized = note == null ? "" : note.toLowerCase().trim();
+
+        if (!normalized.isBlank()) {
+            return NOTE_MAPPING.get(normalized);
+        }
+
+        // No note text to go on: amount == 100.00 exactly closes an off-by-one
+        // gap in the old BackfillNotesMigration ("motor ride app" rule used
+        // strict "< 100"); anything else with no signal defaults to Ride-Hailing.
+        if (Math.abs(amount - 100.0) < 0.01) {
+            return new CategoryNote("Ride-Hailing", "motor ride app");
+        }
+        return new CategoryNote("Ride-Hailing", "grab");
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -12,15 +12,21 @@ app:
     client-id: ${GOOGLE_CLIENT_ID}
   expense-categories:
     - Allowance
+    - Car Loan
+    - Car Maintenance
     - Food & Drinks
+    - Fuel
     - Groceries
     - Health & Medical
     - Holidays & Events
     - Housing
+    - Incident/Emergencies
     - Life & Entertainment
     - Others
+    - Parking
     - Pets, animals
+    - Ride-Hailing
     - Shopping
     - Sports & Fitness
     - Technology & Communication
-    - Transportation
+    - Toll

--- a/frontend/components/ExpenseDistributionWidget.tsx
+++ b/frontend/components/ExpenseDistributionWidget.tsx
@@ -24,19 +24,25 @@ const getPeriodLabel = (period: TrendPeriod): string => {
 const getCategoryColor = (category: string): string => {
   const colorMap: Record<string, string> = {
     [Category.ALLOWANCE]: customColors.iconForegrounds.green,
+    [Category.CAR_LOAN]: customColors.iconForegrounds.purple,
+    [Category.CAR_MAINTENANCE]: customColors.iconForegrounds.gray,
     [Category.FOOD_DRINKS]: customColors.iconForegrounds.orange,
+    [Category.FUEL]: customColors.iconForegrounds.amber,
     [Category.GROCERIES]: customColors.iconForegrounds.cyan,
     [Category.HEALTH_MEDICAL]: customColors.iconForegrounds.pink,
     [Category.HOLIDAYS_EVENTS]: customColors.iconForegrounds.purple,
     [Category.HOUSING]: customColors.iconForegrounds.blue,
+    [Category.INCIDENT_EMERGENCIES]: customColors.iconForegrounds.pink,
     [Category.INCOME]: customColors.iconForegrounds.lightGreen,
     [Category.LIFE_ENTERTAINMENT]: customColors.iconForegrounds.magenta,
     [Category.OTHERS]: customColors.iconForegrounds.gray,
+    [Category.PARKING]: customColors.iconForegrounds.deepOrange,
     [Category.PETS_ANIMALS]: customColors.iconForegrounds.amber,
+    [Category.RIDE_HAILING]: customColors.iconForegrounds.teal,
     [Category.SHOPPING]: customColors.iconForegrounds.yellow,
     [Category.SPORTS_FITNESS]: customColors.iconForegrounds.teal,
     [Category.TECHNOLOGY_COMMUNICATION]: customColors.iconForegrounds.indigo,
-    [Category.TRANSPORTATION]: customColors.iconForegrounds.deepOrange,
+    [Category.TOLL]: customColors.iconForegrounds.cyan,
   };
 
   return colorMap[category] || customColors.iconForegrounds.gray;

--- a/frontend/types/category.ts
+++ b/frontend/types/category.ts
@@ -1,16 +1,22 @@
 export enum Category {
   ALLOWANCE = 'Allowance',
+  CAR_LOAN = 'Car Loan',
+  CAR_MAINTENANCE = 'Car Maintenance',
   FOOD_DRINKS = 'Food & Drinks',
+  FUEL = 'Fuel',
   GROCERIES = 'Groceries',
   HEALTH_MEDICAL = 'Health & Medical',
   HOLIDAYS_EVENTS = 'Holidays & Events',
   HOUSING = 'Housing',
+  INCIDENT_EMERGENCIES = 'Incident/Emergencies',
   INCOME = 'Income',
   LIFE_ENTERTAINMENT = 'Life & Entertainment',
   OTHERS = 'Others',
+  PARKING = 'Parking',
   PETS_ANIMALS = 'Pets, animals',
+  RIDE_HAILING = 'Ride-Hailing',
   SHOPPING = 'Shopping',
   SPORTS_FITNESS = 'Sports & Fitness',
   TECHNOLOGY_COMMUNICATION = 'Technology & Communication',
-  TRANSPORTATION = 'Transportation'
+  TOLL = 'Toll'
 }

--- a/frontend/utils/categoryIcons.tsx
+++ b/frontend/utils/categoryIcons.tsx
@@ -6,19 +6,25 @@ import { customColors } from '../config/theme';
 export const getCategoryIcon = (category: string, size: number = 24) => {
   const iconMap: Record<string, JSX.Element> = {
     [Category.ALLOWANCE]: <Ionicons name="cash-outline" size={size} color={customColors.iconForegrounds.green} />,
+    [Category.CAR_LOAN]: <Ionicons name="receipt-outline" size={size} color={customColors.iconForegrounds.purple} />,
+    [Category.CAR_MAINTENANCE]: <Ionicons name="construct-outline" size={size} color={customColors.iconForegrounds.teal} />,
     [Category.FOOD_DRINKS]: <Ionicons name="restaurant-outline" size={size} color={customColors.iconForegrounds.orange} />,
-    [Category.GROCERIES]: <Ionicons name="cart-outline" size={size} color={customColors.iconForegrounds.teal} />,
+    [Category.FUEL]: <Ionicons name="flame-outline" size={size} color={customColors.iconForegrounds.amber} />,
+    [Category.GROCERIES]: <Ionicons name="cart-outline" size={size} color={customColors.iconForegrounds.cyan} />,
     [Category.HEALTH_MEDICAL]: <Ionicons name="medical-outline" size={size} color={customColors.iconForegrounds.pink} />,
     [Category.HOLIDAYS_EVENTS]: <Ionicons name="balloon-outline" size={size} color={customColors.iconForegrounds.purple} />,
     [Category.HOUSING]: <Ionicons name="home-outline" size={size} color={customColors.iconForegrounds.blue} />,
+    [Category.INCIDENT_EMERGENCIES]: <Ionicons name="warning-outline" size={size} color={customColors.iconForegrounds.pink} />,
     [Category.INCOME]: <Ionicons name="trending-up-outline" size={size} color={customColors.income} />,
-    [Category.LIFE_ENTERTAINMENT]: <Ionicons name="film-outline" size={size} color={customColors.iconForegrounds.purple} />,
+    [Category.LIFE_ENTERTAINMENT]: <Ionicons name="film-outline" size={size} color={customColors.iconForegrounds.magenta} />,
     [Category.OTHERS]: <Ionicons name="ellipsis-horizontal-outline" size={size} color={customColors.iconForegrounds.gray} />,
+    [Category.PARKING]: <Ionicons name="car-outline" size={size} color={customColors.iconForegrounds.deepOrange} />,
     [Category.PETS_ANIMALS]: <Ionicons name="paw-outline" size={size} color={customColors.iconForegrounds.yellow} />,
+    [Category.RIDE_HAILING]: <Ionicons name="car-sport-outline" size={size} color={customColors.iconForegrounds.indigo} />,
     [Category.SHOPPING]: <Ionicons name="bag-outline" size={size} color={customColors.iconForegrounds.pink} />,
     [Category.SPORTS_FITNESS]: <Ionicons name="fitness-outline" size={size} color={customColors.iconForegrounds.green} />,
     [Category.TECHNOLOGY_COMMUNICATION]: <Ionicons name="laptop-outline" size={size} color={customColors.iconForegrounds.blue} />,
-    [Category.TRANSPORTATION]: <Ionicons name="car-outline" size={size} color={customColors.iconForegrounds.teal} />,
+    [Category.TOLL]: <Ionicons name="card-outline" size={size} color={customColors.iconForegrounds.lightGreen} />,
   };
 
   return iconMap[category] || <Ionicons name="card-outline" size={size} color={customColors.iconForegrounds.gray} />;


### PR DESCRIPTION
## Summary

- Retires the `Transportation` category in favor of 7 dedicated categories: `Parking`, `Ride-Hailing`, `Fuel`, `Toll`, `Car Maintenance`, `Car Loan`, `Incident/Emergencies`.
- Adds a one-off backfill (`BackfillTransportationCategorySplit`) that reassigns existing `Transaction` and `PlannedPayment` records from `Transportation` into the new categories based on note text, normalizing near-duplicate notes within each category. Runs automatically on application boot when `migration.backfill-transportation-category-split.enabled=true` is set (same pattern as `BackfillNotesMigration`) — not exposed as an API endpoint.
- Updates the frontend `Category` enum, category icons/colors, and the backend `application.yaml` `expense-categories` list (used by `ExpenseDistributionService`) to match.

Closes #51.

## Test plan

- [x] `./gradlew compileJava` — compiles clean
- [x] `./gradlew test` — passes
- [x] `npx tsc --noEmit` (frontend) — no type errors
- [x] `npm run lint` (frontend) — no new warnings/errors
- [ ] Deploy with `migration.backfill-transportation-category-split.enabled=true` set for one boot cycle against production, then unset it
- [ ] Manually verify category selector, expense distribution chart, and planned payments screens render the new categories correctly in the app