### PR TITLE
feat(backend): add GET /api/debt-trend endpoint

### DIFF
--- a/backend/src/main/java/com/lazyspender/backend/controller/DebtTrendController.java
+++ b/backend/src/main/java/com/lazyspender/backend/controller/DebtTrendController.java
@@ -1,0 +1,35 @@
+package com.lazyspender.backend.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lazyspender.backend.dto.DebtTrendResponse;
+import com.lazyspender.backend.model.DebtAggregation;
+import com.lazyspender.backend.security.AuthContext;
+import com.lazyspender.backend.service.DebtTrendService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/debt-trend")
+@RequiredArgsConstructor
+public class DebtTrendController {
+
+    private final DebtTrendService debtTrendService;
+
+    @GetMapping
+    public ResponseEntity<DebtTrendResponse> getDebtTrend(
+            @RequestParam(name = "from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(name = "to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(name = "aggregate") DebtAggregation aggregate) {
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(AuthContext.getOwner(), from, to, aggregate);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/lazyspender/backend/dto/DebtCategoryAmount.java
+++ b/backend/src/main/java/com/lazyspender/backend/dto/DebtCategoryAmount.java
@@ -1,0 +1,4 @@
+package com.lazyspender.backend.dto;
+
+public record DebtCategoryAmount(String category, double amount) {
+}

--- a/backend/src/main/java/com/lazyspender/backend/dto/DebtTrendDataPoint.java
+++ b/backend/src/main/java/com/lazyspender/backend/dto/DebtTrendDataPoint.java
@@ -1,0 +1,7 @@
+package com.lazyspender.backend.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DebtTrendDataPoint(String label, Instant timestamp, double totalDebt, List<DebtCategoryAmount> categories) {
+}

--- a/backend/src/main/java/com/lazyspender/backend/dto/DebtTrendResponse.java
+++ b/backend/src/main/java/com/lazyspender/backend/dto/DebtTrendResponse.java
@@ -1,0 +1,7 @@
+package com.lazyspender.backend.dto;
+
+import java.util.List;
+
+public record DebtTrendResponse(double totalDebt, String currency, List<DebtTrendDataPoint> dataPoints,
+        YAxisConfig yAxisConfig) {
+}

--- a/backend/src/main/java/com/lazyspender/backend/model/DebtAggregation.java
+++ b/backend/src/main/java/com/lazyspender/backend/model/DebtAggregation.java
@@ -1,0 +1,6 @@
+package com.lazyspender.backend.model;
+
+public enum DebtAggregation {
+    MONTHLY,
+    YEARLY
+}

--- a/backend/src/main/java/com/lazyspender/backend/service/DebtTrendService.java
+++ b/backend/src/main/java/com/lazyspender/backend/service/DebtTrendService.java
@@ -1,0 +1,193 @@
+package com.lazyspender.backend.service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.lazyspender.backend.dto.DebtCategoryAmount;
+import com.lazyspender.backend.dto.DebtTrendDataPoint;
+import com.lazyspender.backend.dto.DebtTrendResponse;
+import com.lazyspender.backend.dto.YAxisConfig;
+import com.lazyspender.backend.model.DebtAggregation;
+import com.lazyspender.backend.model.EndType;
+import com.lazyspender.backend.model.PaymentStatus;
+import com.lazyspender.backend.model.PlannedPayment;
+import com.lazyspender.backend.model.Transaction;
+import com.lazyspender.backend.repository.PlannedPaymentRepository;
+import com.lazyspender.backend.repository.TransactionRepository;
+import com.lazyspender.backend.util.DateTimeUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DebtTrendService {
+
+    private static final long MAX_RANGE_DAYS = 3653; // ~10 years
+
+    private final PlannedPaymentRepository plannedPaymentRepository;
+    private final TransactionRepository transactionRepository;
+
+    public DebtTrendResponse getDebtTrend(String owner, LocalDate from, LocalDate to, DebtAggregation aggregate) {
+        validateRange(from, to);
+
+        Instant rangeStart = DateTimeUtils.toInstantStartOfDay(from);
+        Instant rangeEnd = to.atTime(LocalTime.MAX).atZone(DateTimeUtils.getUtcZoneId()).toInstant();
+
+        List<PlannedPayment> plannedPayments = plannedPaymentRepository.findByOwner(owner).stream()
+                .filter(payment -> payment.getStatus() != PaymentStatus.CANCELLED)
+                .toList();
+
+        // Fetch once and group in-memory (Datastore has no per-plannedPaymentId aggregate query)
+        List<Transaction> transactions = transactionRepository
+                .findByOwnerAndDateBetweenOrderByDateAsc(owner, Instant.EPOCH, rangeEnd);
+
+        Map<String, List<Instant>> confirmedDatesByPlannedPaymentId = new HashMap<>();
+        for (Transaction transaction : transactions) {
+            if (transaction.getPlannedPaymentId() != null) {
+                confirmedDatesByPlannedPaymentId
+                        .computeIfAbsent(transaction.getPlannedPaymentId(), key -> new ArrayList<>())
+                        .add(transaction.getDate());
+            }
+        }
+
+        List<DebtTrendDataPoint> dataPoints = buildDataPoints(plannedPayments, confirmedDatesByPlannedPaymentId,
+                rangeStart, rangeEnd, aggregate);
+
+        double totalDebt = dataPoints.isEmpty() ? 0 : dataPoints.get(dataPoints.size() - 1).totalDebt();
+        String currency = plannedPayments.isEmpty() ? "PHP" : plannedPayments.get(0).getCurrency();
+        YAxisConfig yAxisConfig = calculateYAxisConfig(dataPoints);
+
+        return new DebtTrendResponse(totalDebt, currency, dataPoints, yAxisConfig);
+    }
+
+    private void validateRange(LocalDate from, LocalDate to) {
+        if (from == null || to == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "from and to are required");
+        }
+        if (from.isAfter(to)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "from must not be after to");
+        }
+        if (ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date range must not exceed 10 years");
+        }
+    }
+
+    private List<DebtTrendDataPoint> buildDataPoints(List<PlannedPayment> plannedPayments,
+            Map<String, List<Instant>> confirmedDatesByPlannedPaymentId, Instant rangeStart, Instant rangeEnd,
+            DebtAggregation aggregate) {
+
+        List<DebtTrendDataPoint> dataPoints = new ArrayList<>();
+
+        ZonedDateTime bucketStart = getInitialBucketStart(rangeStart, aggregate);
+        ZonedDateTime rangeEndDateTime = DateTimeUtils.toUtcZonedDateTime(rangeEnd);
+
+        while (bucketStart.isBefore(rangeEndDateTime)) {
+            ZonedDateTime nextBucketStart = getNextBucketStart(bucketStart, aggregate);
+            Instant bucketEndExclusive = nextBucketStart.toInstant();
+
+            Map<String, Double> amountByCategory = new HashMap<>();
+            for (PlannedPayment payment : plannedPayments) {
+                double amount = calculateOutstandingAmount(payment, confirmedDatesByPlannedPaymentId, bucketEndExclusive);
+                if (amount > 0) {
+                    amountByCategory.merge(payment.getCategory(), amount, Double::sum);
+                }
+            }
+
+            List<DebtCategoryAmount> categories = amountByCategory.entrySet().stream()
+                    .map(entry -> new DebtCategoryAmount(entry.getKey(), entry.getValue()))
+                    .toList();
+
+            double totalDebt = categories.stream().mapToDouble(DebtCategoryAmount::amount).sum();
+
+            dataPoints.add(new DebtTrendDataPoint(formatLabel(bucketStart, aggregate), bucketStart.toInstant(),
+                    totalDebt, categories));
+
+            bucketStart = nextBucketStart;
+        }
+
+        return dataPoints;
+    }
+
+    /**
+     * Outstanding amount for a payment as of a bucket's (exclusive) end instant.
+     * OCCURRENCE payments shrink toward zero as linked transactions are confirmed;
+     * NEVER payments contribute a flat recurring amount since they have no finite payoff.
+     */
+    private double calculateOutstandingAmount(PlannedPayment payment,
+            Map<String, List<Instant>> confirmedDatesByPlannedPaymentId, Instant bucketEndExclusive) {
+
+        if (!payment.getStartDate().isBefore(bucketEndExclusive)) {
+            return 0;
+        }
+
+        if (payment.getEndType() == EndType.NEVER) {
+            return payment.getAmount();
+        }
+
+        if (payment.getEndType() == EndType.OCCURRENCE) {
+            int totalOccurrences = Integer.parseInt(payment.getEndValue());
+            List<Instant> confirmedDates = confirmedDatesByPlannedPaymentId.getOrDefault(payment.getId(), List.of());
+            long confirmedCount = confirmedDates.stream()
+                    .filter(date -> date.isBefore(bucketEndExclusive))
+                    .count();
+            long remainingOccurrences = Math.max(0, totalOccurrences - confirmedCount);
+            return remainingOccurrences * payment.getAmount();
+        }
+
+        // EndType.DATE is rejected by PlannedPaymentService.validateRequest today; no production data reaches here.
+        return payment.getAmount();
+    }
+
+    private ZonedDateTime getInitialBucketStart(Instant rangeStart, DebtAggregation aggregate) {
+        ZonedDateTime zdt = DateTimeUtils.toUtcZonedDateTime(rangeStart);
+        return switch (aggregate) {
+            case MONTHLY -> zdt.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+            case YEARLY -> zdt.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS);
+        };
+    }
+
+    private ZonedDateTime getNextBucketStart(ZonedDateTime bucketStart, DebtAggregation aggregate) {
+        return switch (aggregate) {
+            case MONTHLY -> bucketStart.plusMonths(1);
+            case YEARLY -> bucketStart.plusYears(1);
+        };
+    }
+
+    private String formatLabel(ZonedDateTime bucketStart, DebtAggregation aggregate) {
+        DateTimeFormatter formatter = switch (aggregate) {
+            case MONTHLY -> DateTimeFormatter.ofPattern("MMM yyyy");
+            case YEARLY -> DateTimeFormatter.ofPattern("yyyy");
+        };
+        return bucketStart.format(formatter);
+    }
+
+    private YAxisConfig calculateYAxisConfig(List<DebtTrendDataPoint> dataPoints) {
+        double maxDebt = dataPoints.stream()
+                .mapToDouble(DebtTrendDataPoint::totalDebt)
+                .max()
+                .orElse(0);
+
+        double maxValue = Math.ceil(maxDebt / 100000.0) * 100000.0;
+        if (maxValue < 100000) {
+            maxValue = 100000;
+        }
+
+        return YAxisConfig.builder()
+                .minValue(0)
+                .maxValue(maxValue)
+                .interval(maxValue / 5)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/lazyspender/backend/service/DebtTrendServiceTest.java
+++ b/backend/src/test/java/com/lazyspender/backend/service/DebtTrendServiceTest.java
@@ -1,0 +1,300 @@
+package com.lazyspender.backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.lazyspender.backend.dto.DebtCategoryAmount;
+import com.lazyspender.backend.dto.DebtTrendDataPoint;
+import com.lazyspender.backend.dto.DebtTrendResponse;
+import com.lazyspender.backend.model.DebtAggregation;
+import com.lazyspender.backend.model.EndType;
+import com.lazyspender.backend.model.PaymentStatus;
+import com.lazyspender.backend.model.PlannedPayment;
+import com.lazyspender.backend.model.Transaction;
+import com.lazyspender.backend.repository.PlannedPaymentRepository;
+import com.lazyspender.backend.repository.TransactionRepository;
+import com.lazyspender.backend.util.DateTimeUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DebtTrendServiceTest {
+
+    private static final String OWNER = "test-owner";
+
+    @Mock
+    private PlannedPaymentRepository plannedPaymentRepository;
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private DebtTrendService debtTrendService;
+
+    // === Validation ===
+
+    @Test
+    void throwsBadRequestWhenFromIsNull() {
+        ResponseStatusException exception = catchThrowableOfType(
+                () -> debtTrendService.getDebtTrend(OWNER, null, LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY),
+                ResponseStatusException.class);
+
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getReason()).isEqualTo("from and to are required");
+    }
+
+    @Test
+    void throwsBadRequestWhenToIsNull() {
+        ResponseStatusException exception = catchThrowableOfType(
+                () -> debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1), null, DebtAggregation.MONTHLY),
+                ResponseStatusException.class);
+
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getReason()).isEqualTo("from and to are required");
+    }
+
+    @Test
+    void throwsBadRequestWhenFromIsAfterTo() {
+        ResponseStatusException exception = catchThrowableOfType(
+                () -> debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 2, 1), LocalDate.of(2026, 1, 1),
+                        DebtAggregation.MONTHLY),
+                ResponseStatusException.class);
+
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getReason()).isEqualTo("from must not be after to");
+    }
+
+    @Test
+    void throwsBadRequestWhenRangeExceedsTenYears() {
+        ResponseStatusException exception = catchThrowableOfType(
+                () -> debtTrendService.getDebtTrend(OWNER, LocalDate.of(2010, 1, 1), LocalDate.of(2025, 1, 2),
+                        DebtAggregation.MONTHLY),
+                ResponseStatusException.class);
+
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getReason()).isEqualTo("date range must not exceed 10 years");
+    }
+
+    // === Debt calculation ===
+
+    @Test
+    void neverEndingPaymentContributesFlatAmountToEachBucketAfterStart() {
+        PlannedPayment payment = neverEndingPayment("p1", "Rent", 1000, LocalDate.of(2026, 1, 15));
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 3, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::label)
+                .containsExactly("Jan 2026", "Feb 2026", "Mar 2026");
+        assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::totalDebt)
+                .containsExactly(1000.0, 1000.0, 1000.0);
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Rent", 1000));
+        assertThat(response.totalDebt()).isEqualTo(1000.0);
+        assertThat(response.currency()).isEqualTo("PHP");
+    }
+
+    @Test
+    void occurrencePaymentShrinksAsTransactionsAreConfirmed() {
+        PlannedPayment payment = occurrencePayment("p2", "Loan", 500, LocalDate.of(2026, 1, 1), 3);
+        List<Transaction> transactions = List.of(
+                confirmedTransaction("p2", LocalDate.of(2026, 1, 10)),
+                confirmedTransaction("p2", LocalDate.of(2026, 2, 15)));
+        stubRepositories(List.of(payment), transactions);
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 3, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::totalDebt)
+                .containsExactly(1000.0, 500.0, 500.0);
+        assertThat(response.totalDebt()).isEqualTo(500.0);
+    }
+
+    @Test
+    void occurrencePaymentReachesZeroOnceAllOccurrencesAreConfirmed() {
+        PlannedPayment payment = occurrencePayment("p3", "Loan", 500, LocalDate.of(2026, 1, 1), 1);
+        List<Transaction> transactions = List.of(confirmedTransaction("p3", LocalDate.of(2026, 1, 10)));
+        stubRepositories(List.of(payment), transactions);
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints()).hasSize(1);
+        assertThat(response.dataPoints().get(0).totalDebt()).isEqualTo(0.0);
+        assertThat(response.dataPoints().get(0).categories()).isEmpty();
+        assertThat(response.totalDebt()).isEqualTo(0.0);
+    }
+
+    @Test
+    void cancelledPaymentsAreExcludedFromDebt() {
+        PlannedPayment active = neverEndingPayment("p1", "Utilities", 200, LocalDate.of(2025, 12, 1));
+        PlannedPayment cancelled = neverEndingPayment("p2", "ShouldBeExcluded", 999999, LocalDate.of(2025, 12, 1));
+        cancelled.setStatus(PaymentStatus.CANCELLED);
+        stubRepositories(List.of(active, cancelled), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints()).hasSize(1);
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 200));
+        assertThat(response.totalDebt()).isEqualTo(200.0);
+    }
+
+    @Test
+    void paymentNotYetStartedContributesZero() {
+        PlannedPayment payment = neverEndingPayment("p1", "Future", 1000, LocalDate.of(2026, 4, 1));
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 3, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::totalDebt).containsExactly(0.0, 0.0, 0.0);
+        assertThat(response.dataPoints()).allSatisfy(dp -> assertThat(dp.categories()).isEmpty());
+        assertThat(response.totalDebt()).isEqualTo(0.0);
+    }
+
+    @Test
+    void paymentsInSameCategoryAreAggregated() {
+        PlannedPayment rentA = neverEndingPayment("p1", "Utilities", 200, LocalDate.of(2025, 12, 1));
+        PlannedPayment rentB = neverEndingPayment("p2", "Utilities", 300, LocalDate.of(2025, 12, 1));
+        stubRepositories(List.of(rentA, rentB), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 500));
+        assertThat(response.totalDebt()).isEqualTo(500.0);
+    }
+
+    @Test
+    void yearlyAggregationProducesOneBucketPerYear() {
+        PlannedPayment payment = neverEndingPayment("p1", "X", 100, LocalDate.of(2024, 1, 1));
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2024, 1, 1),
+                LocalDate.of(2026, 12, 31), DebtAggregation.YEARLY);
+
+        assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::label).containsExactly("2024", "2025", "2026");
+        assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::totalDebt).containsExactly(100.0, 100.0, 100.0);
+    }
+
+    @Test
+    void currencyDefaultsToPhpWhenNoPlannedPayments() {
+        stubRepositories(List.of(), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.currency()).isEqualTo("PHP");
+        assertThat(response.totalDebt()).isEqualTo(0.0);
+    }
+
+    @Test
+    void currencyUsesFirstPlannedPaymentCurrency() {
+        PlannedPayment payment = neverEndingPayment("p1", "X", 100, LocalDate.of(2025, 12, 1));
+        payment.setCurrency("USD");
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.currency()).isEqualTo("USD");
+    }
+
+    @Test
+    void dateEndTypeFallsBackToFlatAmount() {
+        PlannedPayment payment = neverEndingPayment("p1", "Y", 150, LocalDate.of(2025, 12, 1));
+        payment.setEndType(EndType.DATE);
+        payment.setEndValue("2030-01-01");
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints().get(0).totalDebt()).isEqualTo(150.0);
+    }
+
+    // === Y-axis scaling ===
+
+    @Test
+    void yAxisConfigScalesToNearestHundredThousandAboveMaxDebt() {
+        PlannedPayment payment = neverEndingPayment("p1", "Big", 250000, LocalDate.of(2025, 12, 1));
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.yAxisConfig().getMinValue()).isEqualTo(0);
+        assertThat(response.yAxisConfig().getMaxValue()).isEqualTo(300000);
+        assertThat(response.yAxisConfig().getInterval()).isEqualTo(60000);
+    }
+
+    @Test
+    void yAxisConfigFloorsAtHundredThousandWhenDebtIsLow() {
+        stubRepositories(List.of(), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.yAxisConfig().getMinValue()).isEqualTo(0);
+        assertThat(response.yAxisConfig().getMaxValue()).isEqualTo(100000);
+        assertThat(response.yAxisConfig().getInterval()).isEqualTo(20000);
+    }
+
+    // === Helpers ===
+
+    private void stubRepositories(List<PlannedPayment> payments, List<Transaction> transactions) {
+        when(plannedPaymentRepository.findByOwner(OWNER)).thenReturn(payments);
+        when(transactionRepository.findByOwnerAndDateBetweenOrderByDateAsc(eq(OWNER), any(Instant.class),
+                any(Instant.class))).thenReturn(transactions);
+    }
+
+    private PlannedPayment neverEndingPayment(String id, String category, double amount, LocalDate startDate) {
+        return PlannedPayment.builder()
+                .id(id)
+                .owner(OWNER)
+                .category(category)
+                .amount(amount)
+                .currency("PHP")
+                .startDate(DateTimeUtils.toInstantStartOfDay(startDate))
+                .endType(EndType.NEVER)
+                .status(PaymentStatus.ACTIVE)
+                .build();
+    }
+
+    private PlannedPayment occurrencePayment(String id, String category, double amount, LocalDate startDate,
+            int totalOccurrences) {
+        return PlannedPayment.builder()
+                .id(id)
+                .owner(OWNER)
+                .category(category)
+                .amount(amount)
+                .currency("PHP")
+                .startDate(DateTimeUtils.toInstantStartOfDay(startDate))
+                .endType(EndType.OCCURRENCE)
+                .endValue(String.valueOf(totalOccurrences))
+                .status(PaymentStatus.ACTIVE)
+                .build();
+    }
+
+    private Transaction confirmedTransaction(String plannedPaymentId, LocalDate date) {
+        return Transaction.builder()
+                .owner(OWNER)
+                .plannedPaymentId(plannedPaymentId)
+                .date(DateTimeUtils.toInstantStartOfDay(date))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/debt-trend?from={date}&to={date}&aggregate={MONTHLY|YEARLY}`, returning total outstanding debt aggregated into time buckets for the caller's owner (FR1, FR3, FR4).
- Debt = outstanding `PlannedPayment` obligations (status != CANCELLED): `OCCURRENCE`-ended payments shrink toward zero as linked transactions are confirmed (`amount * remaining occurrences`); `NEVER`-ended payments contribute a flat recurring `amount` per bucket since they have no finite payoff.
- Each bucket includes a per-category breakdown (`DebtCategoryAmount`) for a stacked-bar chart, plus a bucket total and top-level `YAxisConfig`.
- Basic input validation (S6): `from`/`to`/`aggregate` required, `from <= to`, and a 10-year max range sanity check.
- Reuses existing `PlannedPaymentRepository.findByOwner` and `TransactionRepository.findByOwnerAndDateBetweenOrderByDateAsc` — no new Datastore composite indexes needed.

Frontend widget (S2-S5) will follow in a separate issue/branch.

Closes #50

## Test plan
- [x] `./gradlew compileJava` — builds clean
- [x] `./gradlew test` — full suite passes
- [ ] Manual exercise via Bruno/`curl` against a local run with real planned payment data (not yet done — no test data readily available in this session)