### PR TITLE
chore: fix dev environment setup (Java runtime path, gitignore, sdkmanrc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Per-task git worktrees (see CLAUDE.md dev workflow) — these are separate
+# checkouts of this same repo and must never be tracked from the parent.
+.claude/worktrees/
+
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editors/IDEs (repo-wide; .vscode/ itself is intentionally tracked)
+.idea/
+*.swp
+*.swo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,13 +7,6 @@
   "java.compile.nullAnalysis.mode": "automatic",
   "java.autobuild.enabled": true,
   "java.configuration.updateBuildConfiguration": "automatic",
-  "java.configuration.runtimes": [
-    {
-      "name": "JavaSE-21",
-      "path": "/Users/personal/.sdkman/candidates/java/current",
-      "default": true
-    }
-  ],
   "files.exclude": {
     "**/.gradle": true,
     "**/build": false

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,12 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Env / secrets ###
+.env
+.env.*
+!.env.example
+
+### Logs ###
+*.log
+logs/

--- a/backend/.sdkmanrc
+++ b/backend/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=21.0.11-zulu


### PR DESCRIPTION
## Summary
- Removed a hardcoded Mac-only JDK path from tracked `.vscode/settings.json` (`java.configuration.runtimes`) that broke the Java extension on non-Mac machines; falls back to auto-detecting via `JAVA_HOME`.
- Added root `.gitignore` for OS files, editor/IDE noise, and worktree checkouts.
- Extended `backend/.gitignore` to cover `.env`/secrets and log files.
- Added `backend/.sdkmanrc` to pin the Java version (21.0.11-zulu) for sdkman auto-env.

## Test plan
- [x] Verified `JAVA_HOME` resolves correctly on Windows without the explicit runtime override
- [x] Confirmed `.vscode/settings.json` still has valid JSON after the edit

Closes #55