### PR TITLE
chore(backend): enable transportation category backfill on boot

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -30,3 +30,7 @@ app:
     - Sports & Fitness
     - Technology & Communication
     - Toll
+
+migration:
+  backfill-transportation-category-split:
+    enabled: true


### PR DESCRIPTION
## Summary
- Sets `migration.backfill-transportation-category-split.enabled: true` in `backend/src/main/resources/application.yaml` so `BackfillTransportationCategorySplit` (added in #52) actually runs on next boot, instead of silently no-oping because the property was never set anywhere.

Closes #54.

## Test plan
- [x] `./gradlew compileJava` — compiles clean
- [x] `./gradlew test` — passes
- [ ] Deploy and confirm via prod logs that the migration ran and updated the expected `Transportation`-tagged records
- [ ] Follow-up: flip `enabled` back to `false` once confirmed, so boot doesn't keep scanning all transactions/planned payments indefinitely