### PR TITLE
fix(backend): disable boot-gated migrations in test profile

### DIFF
--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -7,3 +7,9 @@ app:
     secret: "test-only-secret-do-not-use-in-prod-32chars-minimum"
   google:
     client-id: "test-client-id.apps.googleusercontent.com"
+
+# Boot-gated one-off migrations must never run against real Datastore during
+# automated tests, regardless of what the default profile enables.
+migration:
+  backfill-transportation-category-split:
+    enabled: false


### PR DESCRIPTION
## Summary
- `BackfillTransportationCategorySplit` runs on every Spring Boot context boot when its property is enabled (turned on in #57), including `@SpringBootTest` contexts, since `application-test.yaml` didn't override it.
- In CI, that runner queried real prod Firestore during test context startup and failed (credentials there aren't scoped for Datastore), taking down `BackendApplicationTests` and `SecurityConfigTest` with it.
- Adds `migration.backfill-transportation-category-split.enabled: false` to `backend/src/test/resources/application-test.yaml` so boot-gated migrations never run against real Datastore during automated tests.

Closes #58.

## Test plan
- [x] `./gradlew test --tests BackendApplicationTests --tests SecurityConfigTest` passes locally
- [x] Full `./gradlew test` passes (23/23)
- [x] `./gradlew build` succeeds