### PR TITLE
feat(frontend): auto-fill note for Toll, Parking, Fuel, and Income categories

### DIFF
--- a/frontend/components/TransactionFormModal.tsx
+++ b/frontend/components/TransactionFormModal.tsx
@@ -26,6 +26,13 @@ interface TransactionFormModalProps {
   initialData: CreateTransactionRequest | undefined
 }
 
+const AUTO_FILL_NOTE_BY_CATEGORY: Partial<Record<Category, string>> = {
+  [Category.TOLL]: 'toll',
+  [Category.PARKING]: 'parking',
+  [Category.FUEL]: 'fuel',
+  [Category.INCOME]: 'salary',
+};
+
 const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, onClose, initialData }) => {
   const { delegatedOwner } = useAccessContext();
   const { data: user } = useActiveUser(delegatedOwner);
@@ -173,7 +180,15 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, on
             {categorySelectorVisible ? (
               <CategorySelectorModal
                 selectedCategory={formData.category as Category}
-                onSelect={(category) => setFormData({ ...formData, category })}
+                onSelect={(category) => setFormData((prev) => {
+                  const autoFillNote = AUTO_FILL_NOTE_BY_CATEGORY[category];
+                  const shouldAutoFillNote = !isEditMode && autoFillNote && !prev.note;
+                  return {
+                    ...prev,
+                    category,
+                    note: shouldAutoFillNote ? autoFillNote : prev.note,
+                  };
+                })}
                 onClose={() => setCategorySelectorVisible(false)}
               />
             ) : (


### PR DESCRIPTION
## Summary
- Selecting Toll, Parking, Fuel, or Income when creating a new transaction now pre-fills the Notes field (lowercase; Income fills in as "salary")
- Does not override a note the user already typed, and only applies when creating a transaction (not editing an existing one)

Closes #60

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint components/TransactionFormModal.tsx` passes
- [ ] Could not exercise the flow in a running browser/emulator — the app now requires real Google Sign-In and web SSO is sponsor-only/unimplemented, with no local dev auth bypass. Verified via code read: `CategorySelectorModal.handleSelectCategory` calls `onSelect(category)` synchronously before closing, which triggers the new functional `setFormData` update in `TransactionFormModal.tsx`.