### PR TITLE
Verify actuator health response status, not just HTTP success

### DIFF
--- a/frontend/services/health.service.ts
+++ b/frontend/services/health.service.ts
@@ -1,15 +1,22 @@
 import { apiClient } from '../config/api';
 
+interface HealthResponse {
+  status: string;
+}
+
 /**
  * Pings the backend's actuator health endpoint. Used to detect when a Cloud
  * Run instance that scaled to zero has finished cold-starting, and returns
- * false (not just for a cold start, but also a 503) if any health indicator
- * - e.g. the Datastore connection - reports DOWN.
+ * false (not just for a cold start, but also a 503, or a 200 with a non-UP
+ * body) if any health indicator - e.g. the Datastore connection - isn't UP.
+ * Checked against the body rather than just the HTTP status because
+ * actuator's default status-to-HTTP-code mapping treats UNKNOWN the same as
+ * UP (200).
  */
 export const pingHealth = async (): Promise<boolean> => {
   try {
-    await apiClient.get('/actuator/health', { timeout: 3000 });
-    return true;
+    const response = await apiClient.get<HealthResponse>('/actuator/health', { timeout: 3000 });
+    return response.data.status === 'UP';
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- \`pingHealth\` now checks \`response.data.status === 'UP'\` explicitly instead of treating any non-throwing HTTP response as ready.
- Previously it only relied on the request not throwing, which happened to work for DOWN/OUT_OF_SERVICE (actuator maps those to a 503, which axios throws on) but would have misread an UNKNOWN status (still HTTP 200) as ready.

This was written on the `feature/63-server-warmup-loading-screen` branch but committed after PR #64 had already been squash-merged, so it never landed on main. This PR lands it.

Closes #66.

## Test plan
- [x] `npx tsc --noEmit` and `npm run lint` pass with no new errors
- [x] Verified against a locally-running backend that `/actuator/health` returns `{"status":"UP"}` when healthy