### PR TITLE
fix: local actuator CORS block and stale metro cache

### DIFF
--- a/backend/src/main/java/com/lazyspender/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/lazyspender/backend/config/WebConfig.java
@@ -1,24 +1,39 @@
 package com.lazyspender.backend.config;
 
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
+public class WebConfig {
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOriginPatterns(
-                        "http://localhost:*",              // Local development (any port)
-                        "exp://*",                         // Expo Go (any host/port)
-                        "http://192.168.*.*:*",            // Local network IPs (any port)
-                        "http://10.*.*.*:*"                // Private network range (any port)
-                )
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3600);
+    // Registered with Spring Security (see SecurityConfig#securityFilterChain) rather than via
+    // WebMvcConfigurer#addCorsMappings, because that WebMvcConfigurer hook only covers
+    // RequestMappingHandlerMapping (regular @RestController endpoints) - it silently skips
+    // /actuator/** requests, which are served by a separate WebMvcEndpointHandlerMapping, causing
+    // real browser CORS preflights to actuator endpoints to be rejected even though this "/**"
+    // pattern nominally covers them. Spring Security's CorsFilter runs earlier in the chain and
+    // applies uniformly to every request regardless of which handler mapping ultimately serves it.
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of(
+                "http://localhost:*",              // Local development (any port)
+                "exp://*",                         // Expo Go (any host/port)
+                "http://192.168.*.*:*",            // Local network IPs (any port)
+                "http://10.*.*.*:*"                // Private network range (any port)
+        ));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/backend/src/main/java/com/lazyspender/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/lazyspender/backend/security/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,10 +22,12 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final DelegatedAccessFilter delegatedAccessFilter;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -19,6 +19,9 @@ if [ ! -f "$GIT_BASH" ]; then
 fi
 
 "$GIT_BASH" -c "cd '$REPO_ROOT/backend' && ./gradlew bootRunLocal; exec bash" &
-"$GIT_BASH" -c "cd '$REPO_ROOT/frontend' && npm run web; exec bash" &
+# -c clears the Metro bundler cache on every launch - a stale cache can keep serving a bundle
+# built against a previous API_BASE_URL (e.g. the deployed Cloud Run URL) even after
+# frontend/.env.local is added/changed, which surfaces as a CORS error against the wrong host.
+"$GIT_BASH" -c "cd '$REPO_ROOT/frontend' && npm run web -- -c; exec bash" &
 
-echo "Spawned backend (bootRunLocal) and frontend (npm run web) in separate Git Bash windows."
+echo "Spawned backend (bootRunLocal) and frontend (npm run web, cache cleared) in separate Git Bash windows."


### PR DESCRIPTION
## Summary
- Local web dev was stuck forever on "Waking up the server..." against a healthy local backend. `WebConfig.addCorsMappings()` only applied CORS to standard `@RestController` endpoints (Spring MVC's `RequestMappingHandlerMapping`) - actuator endpoints use a separate `WebMvcEndpointHandlerMapping` that hook never touches, so cross-origin preflights to `/actuator/health` were rejected with `403 Invalid CORS request`. `curl` never showed this since it doesn't enforce CORS.
- Fix: move CORS config into a `CorsConfigurationSource` bean wired into Spring Security's `http.cors(...)`, whose `CorsFilter` runs early in the chain and applies to every request regardless of handler mapping.
- `scripts/run-local.sh` now clears the Metro bundler cache on every launch (`npm run web -- -c`), since a stale bundle can otherwise keep pointing at the deployed Cloud Run URL after `frontend/.env.local` is added/changed.

Closes #69

## Test plan
- [x] Verified `/actuator/health` preflight (`OPTIONS` with `Origin: http://localhost:3000`) returns 200 with `Access-Control-Allow-Origin` after the fix, vs 403 before
- [x] Verified in a real browser against a locally-run backend: app clears the warmup screen and reaches `/login` instead of hanging
- [x] `./gradlew compileJava` passes