### PR TITLE
feat(frontend): add Google Identity Services sign-in for web

### DIFF
--- a/frontend/app/login.web.tsx
+++ b/frontend/app/login.web.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Text, useTheme } from 'react-native-paper';
+import { useAuth } from '../hooks/useAuth.web';
+import { spacing } from '../config/theme';
+
+export default function LoginScreen() {
+  const theme = useTheme();
+  const { isReady, isSigningIn, error, renderButton } = useAuth();
+  const buttonContainerRef = useRef<View>(null);
+
+  useEffect(() => {
+    if (isReady) {
+      renderButton(buttonContainerRef.current);
+    }
+  }, [isReady, renderButton]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.primary }]}>
+        LazySpender
+      </Text>
+      <Text variant="bodyMedium" style={[styles.subtitle, { color: theme.colors.onSurfaceVariant }]}>
+        Sign in to track your income and expenses.
+      </Text>
+
+      <View ref={buttonContainerRef} style={styles.button} />
+      {(isSigningIn || !isReady) && <ActivityIndicator style={styles.spinner} />}
+
+      {error && (
+        <Text variant="bodySmall" style={[styles.error, { color: theme.colors.error }]}>
+          {error.message}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xxl,
+  },
+  title: {
+    fontWeight: '700',
+    letterSpacing: 0.9,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    textAlign: 'center',
+    marginBottom: spacing.xxxl,
+  },
+  button: {
+    minHeight: 40,
+  },
+  spinner: {
+    marginTop: spacing.lg,
+  },
+  error: {
+    marginTop: spacing.lg,
+    textAlign: 'center',
+  },
+});

--- a/frontend/hooks/useAuth.web.ts
+++ b/frontend/hooks/useAuth.web.ts
@@ -1,0 +1,112 @@
+import Constants from 'expo-constants';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuthContext } from '../contexts/AuthContext';
+import { authenticateWithGoogle } from '../services/auth.service';
+
+const GSI_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+let gsiScriptPromise: Promise<void> | null = null;
+
+// @react-native-google-signin/google-signin is native-only (it throws on import via
+// TurboModuleRegistry.getEnforcing when there's no native module registered), so web
+// uses Google Identity Services directly instead. See docs/google-sso-onboarding-design.md.
+function loadGsiScript(): Promise<void> {
+  if (window.google?.accounts?.id) {
+    return Promise.resolve();
+  }
+
+  if (!gsiScriptPromise) {
+    gsiScriptPromise = new Promise((resolve, reject) => {
+      const existing = document.querySelector(`script[src="${GSI_SCRIPT_SRC}"]`);
+      if (existing) {
+        existing.addEventListener('load', () => resolve());
+        existing.addEventListener('error', () => reject(new Error('Failed to load Google Identity Services script')));
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = GSI_SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error('Failed to load Google Identity Services script'));
+      document.head.appendChild(script);
+    });
+  }
+
+  return gsiScriptPromise;
+}
+
+export const useAuth = () => {
+  const { isAuthenticated, isLoading, signIn, signOut: signOutSession } = useAuthContext();
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const signInRef = useRef(signIn);
+  signInRef.current = signIn;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadGsiScript()
+      .then(() => {
+        if (cancelled) return;
+
+        window.google!.accounts.id.initialize({
+          client_id: Constants.expoConfig?.extra?.googleWebClientId,
+          callback: async (response: { credential: string }) => {
+            setIsSigningIn(true);
+            setError(null);
+            try {
+              const auth = await authenticateWithGoogle(response.credential);
+              await signInRef.current(auth.token);
+            } catch (err) {
+              setError(err instanceof Error ? err : new Error('Sign-in failed'));
+            } finally {
+              setIsSigningIn(false);
+            }
+          },
+        });
+        setIsReady(true);
+      })
+      .catch((err) => setError(err instanceof Error ? err : new Error('Sign-in failed')));
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const renderButton = useCallback((node: unknown) => {
+    if (node && window.google?.accounts?.id) {
+      window.google.accounts.id.renderButton(node, {
+        type: 'standard',
+        theme: 'filled_blue',
+        size: 'large',
+        text: 'signin_with',
+        shape: 'rectangular',
+        logo_alignment: 'left',
+      });
+    }
+  }, []);
+
+  const signOut = async () => {
+    window.google?.accounts?.id?.disableAutoSelect();
+    await signOutSession();
+  };
+
+  return {
+    isAuthenticated,
+    isLoading,
+    isSigningIn,
+    error,
+    isReady,
+    renderButton,
+    signOut,
+  };
+};


### PR DESCRIPTION
## Summary
- Native `@react-native-google-signin/google-signin` is native-only and throws on import via `TurboModuleRegistry.getEnforcing`, crashing every cold web load before it can even reach `/login`.
- Adds a web-only Google Sign-In path using the Google Identity Services (GIS) JS SDK directly, platform-branched via `useAuth.web.ts` / `login.web.tsx` (Metro picks these `.web.*` files for web builds only) — native Android/iOS `useAuth.ts`/`login.tsx` are untouched.
- Reuses the existing `POST /api/auth/google` backend endpoint and `GOOGLE_WEB_CLIENT_ID` — no backend changes needed, since the backend verifies ID tokens by audience regardless of platform.

## Test plan
- [x] `npm run web` loads `/login` without crashing (previously threw immediately)
- [x] Sign-in button renders via GIS `renderButton`
- [x] Full click-through verified locally: GIS button → Google OAuth popup → token exchange → lands on dashboard authenticated

Closes #68

https://claude.ai/code/session_01WfQcxigetvrAX4prqoCbqJ