### PR TITLE
Deploy web frontend to Azure Static Web Apps

### DIFF
--- a/.github/workflows/frontend-web-deploy.yml
+++ b/.github/workflows/frontend-web-deploy.yml
@@ -1,0 +1,40 @@
+name: Frontend Web Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-web-deploy.yml"
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static web export
+        run: npm run web:build
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: frontend/dist
+          output_location: ""
+          skip_app_build: true

--- a/backend/src/main/java/com/lazyspender/backend/config/CorsConfigProperties.java
+++ b/backend/src/main/java/com/lazyspender/backend/config/CorsConfigProperties.java
@@ -1,0 +1,15 @@
+package com.lazyspender.backend.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties(prefix = "app.cors")
+@Data
+public class CorsConfigProperties {
+    private List<String> allowedOriginPatterns = new ArrayList<>();
+}

--- a/backend/src/main/java/com/lazyspender/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/lazyspender/backend/config/WebConfig.java
@@ -8,8 +8,13 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig {
+
+    private final CorsConfigProperties corsConfigProperties;
 
     // Registered with Spring Security (see SecurityConfig#securityFilterChain) rather than via
     // WebMvcConfigurer#addCorsMappings, because that WebMvcConfigurer hook only covers
@@ -21,12 +26,7 @@ public class WebConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of(
-                "http://localhost:*",              // Local development (any port)
-                "exp://*",                         // Expo Go (any host/port)
-                "http://192.168.*.*:*",            // Local network IPs (any port)
-                "http://10.*.*.*:*"                // Private network range (any port)
-        ));
+        configuration.setAllowedOriginPatterns(List.copyOf(corsConfigProperties.getAllowedOriginPatterns()));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -10,6 +10,13 @@ app:
     secret: ${JWT_SECRET}
   google:
     client-id: ${GOOGLE_CLIENT_ID}
+  cors:
+    allowed-origin-patterns:
+      - "http://localhost:*"              # Local development (any port)
+      - "exp://*"                         # Expo Go (any host/port)
+      - "http://192.168.*.*:*"            # Local network IPs (any port)
+      - "http://10.*.*.*:*"               # Private network range (any port)
+      - "https://jolly-mushroom-06ba64b00.7.azurestaticapps.net" # Azure Static Web Apps prod (add a custom domain origin here too, once one exists)
   expense-categories:
     - Allowance
     - Car Loan

--- a/docs/web-sso-and-hosting-plan.md
+++ b/docs/web-sso-and-hosting-plan.md
@@ -70,11 +70,13 @@ Config lives in `frontend/` (not repo root), matching the "no root build, each p
 - `frontend/package.json` — add scripts:
   ```json
   "web:build": "expo export -p web",
-  "web:deploy": "npm run web:build && swa deploy ./dist --deployment-token $AZURE_SWA_DEPLOYMENT_TOKEN --env production",
-  "web:preview": "npm run web:build && swa deploy ./dist --deployment-token $AZURE_SWA_DEPLOYMENT_TOKEN --env preview"
+  "web:deploy": "npm run web:build && swa deploy ./dist --deployment-token $AZURE_SWA_DEPLOYMENT_TOKEN --env production"
   ```
+  (No `web:preview` script — preview environments were considered but dropped to keep v1 scope minimal; see Open Decisions.)
 
-- One-time local/Azure setup: `npm install -g @azure/static-web-apps-cli` and `az login` (interactive). Create the Static Web App **without linking a GitHub repo** (`az staticwebapp create --name lazyspender-web --resource-group <rg> --sku Free --location <region>`), so nothing auto-provisions a GitHub Actions workflow — keeps this in line with "no CI-automated deploy for v1" below. Fetch the deployment token (`az staticwebapp secrets list --name lazyspender-web --query "properties.apiKey" -o tsv`) and store it locally only (gitignored, e.g. `frontend/.env.local`, never committed) as `AZURE_SWA_DEPLOYMENT_TOKEN`.
+- One-time local/Azure setup: `npm install -g @azure/static-web-apps-cli` and `az login` (interactive). Create the Static Web App **without linking a GitHub repo** (`az staticwebapp create --name lazyspender-web --resource-group <rg> --sku Free --location <region>`) — see "CI/CD automation" below for why. Fetch the deployment token (`az staticwebapp secrets list --name lazyspender-web --query "properties.apiKey" -o tsv`).
+
+  **Correction**: an earlier version of this doc suggested storing that token in `frontend/.env.local` as "gitignored, never committed" — that's wrong, `frontend/.env.local` is actually tracked in git (same as `frontend/.env`), so writing a secret there would leak it into the repo. Instead, export it as an ephemeral shell variable (e.g. `$env:AZURE_SWA_DEPLOYMENT_TOKEN` in the current PowerShell session only) for manual deploys, and store it as a GitHub Actions repo secret (`AZURE_STATIC_WEB_APPS_API_TOKEN`) for CI.
 
 **Backend CORS** — `backend/src/main/java/com/lazyspender/backend/config/WebConfig.java`, add to `allowedOriginPatterns(...)`:
 ```java
@@ -85,19 +87,23 @@ Config lives in `frontend/` (not repo root), matching the "no root build, each p
 **Manual GCP Console step (owner: user, outside repo)**: add the same production origin to Authorized JavaScript origins on the Web OAuth client.
 
 **Verification**:
-1. `npm run web:preview` → test login end-to-end on the generated preview-environment URL first (may need temporarily adding that preview hostname to Authorized JavaScript origins, or defer full login verification to production).
-2. Add prod origin to backend CORS + OAuth console, redeploy backend.
-3. `npm run web:deploy` to production; repeat the login + page smoke test from the SSO section against the real production URL.
+1. Add prod origin to backend CORS + OAuth console, redeploy backend.
+2. `npm run web:deploy` to production; repeat the login + page smoke test from the SSO section against the real production URL.
+
+---
+
+## CI/CD automation (added, no longer out of scope for v1)
+
+Once the manual deploy above is verified once, automate it: store the deployment token as a GitHub Actions repo secret (`gh secret set AZURE_STATIC_WEB_APPS_API_TOKEN`) and add `.github/workflows/frontend-web-deploy.yml`, mirroring the existing `backend-deploy.yml`/`frontend-build.yml` shape — build with `npm run web:build`, then deploy with Microsoft's official `Azure/static-web-apps-deploy@v1` action (`skip_app_build: true`, `app_location: frontend/dist`), triggered on push to `main` for `frontend/**` changes. This is why the Static Web App is created **without** linking a GitHub repo at `az staticwebapp create` time — linking it would have Azure auto-generate its own workflow file, which would conflict with this hand-written one.
 
 ---
 
 ## Explicitly Out of Scope for v1
 - Custom domain for Azure Static Web Apps.
-- CI-automated deploys (deploy commands above are run manually for now).
+- Preview/staging deploy environments (`swa deploy --env preview`) — dropped to keep v1 scope minimal; first full verification happens against production.
 - `404.html` / `+not-found.tsx` handling — unmatched routes fall through to Azure Static Web Apps' generic 404 page.
 - httpOnly-cookie session storage for web (see Requirements above — `localStorage` accepted for v1).
 
 ## Open Decisions
 - **RNW `View` ref → DOM node forwarding**: expected to work (RNW 0.21), but unverified — fallback is a raw `<div ref>` in `login.web.tsx` if not.
-- **Preview-environment OAuth origin**: whether to register the `swa deploy --env preview` hostname with GCP for full pre-promotion verification, or accept that first full login verification happens against production.
-- **Azure resource group / region / subscription**: not yet decided — a manual setup decision for whoever implements the hosting piece.
+- **Azure resource group / region / subscription**: resolved during implementation (issue #72) — free-trial subscription, `eastus2` region (one of the small set of regions Static Web Apps supports).

--- a/docs/web-sso-and-hosting-plan.md
+++ b/docs/web-sso-and-hosting-plan.md
@@ -78,11 +78,11 @@ Config lives in `frontend/` (not repo root), matching the "no root build, each p
 
   **Correction**: an earlier version of this doc suggested storing that token in `frontend/.env.local` as "gitignored, never committed" — that's wrong, `frontend/.env.local` is actually tracked in git (same as `frontend/.env`), so writing a secret there would leak it into the repo. Instead, export it as an ephemeral shell variable (e.g. `$env:AZURE_SWA_DEPLOYMENT_TOKEN` in the current PowerShell session only) for manual deploys, and store it as a GitHub Actions repo secret (`AZURE_STATIC_WEB_APPS_API_TOKEN`) for CI.
 
-**Backend CORS** — `backend/src/main/java/com/lazyspender/backend/config/WebConfig.java`, add to `allowedOriginPatterns(...)`:
-```java
-"https://lazyspender-web.azurestaticapps.net"
+**Backend CORS** — allowed origins are externalized to `app.cors.allowed-origin-patterns` in `backend/src/main/resources/application.yaml` (bound via `CorsConfigProperties`, consumed by `WebConfig`) rather than hardcoded in Java, so the list can be changed via a Cloud Run env var override (`APP_CORS_ALLOWEDORIGINPATTERNS`, comma-separated — Spring Boot relaxed binding, verified end-to-end) without a rebuild. The production origin is already in the default list:
+```yaml
+"https://jolly-mushroom-06ba64b00.7.azurestaticapps.net" # Azure Static Web Apps prod (add a custom domain origin here too, once one exists)
 ```
-(Azure Static Web Apps' default domain — placeholder name, replace once the resource is actually created.) Leave a comment placeholder for a future custom domain rather than guessing one now. Redeploy the backend to Cloud Run after this change.
+(This is the real generated hostname for the `lazyspender-web` resource — Azure assigns a random default hostname per-resource, it isn't derived from the resource name.) Redeploy the backend to Cloud Run after this change (or, going forward, just update the `APP_CORS_ALLOWEDORIGINPATTERNS` env var on the Cloud Run service directly).
 
 **Manual GCP Console step (owner: user, outside repo)**: add the same production origin to Authorized JavaScript origins on the Web OAuth client.
 
@@ -106,4 +106,4 @@ Once the manual deploy above is verified once, automate it: store the deployment
 
 ## Open Decisions
 - **RNW `View` ref → DOM node forwarding**: expected to work (RNW 0.21), but unverified — fallback is a raw `<div ref>` in `login.web.tsx` if not.
-- **Azure resource group / region / subscription**: resolved during implementation (issue #72) — free-trial subscription, `eastus2` region (one of the small set of regions Static Web Apps supports).
+- **Azure resource group / region / subscription**: resolved during implementation (issue #72). The original free-trial subscription had already been auto-deleted (exhausted credit, past the reactivation grace period) by the time hosting was set up, so a new Pay-As-You-Go subscription (`lazyspender`) was created instead. Resource group `lazyspender-rg`, Static Web App `lazyspender-web`, both in `eastasia` (closer to the primary user than the originally-planned `eastus2`; one of the small set of regions Static Web Apps supports).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "android": "expo start --android --port 3000",
     "ios": "expo start --ios --port 3000",
     "web": "expo start --web --port 3000",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "web:build": "expo export -p web",
+    "web:deploy": "npm run web:build && swa deploy ./dist --deployment-token $AZURE_SWA_DEPLOYMENT_TOKEN --env production"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -1,0 +1,9 @@
+{
+  "routes": [
+    { "route": "/dashboard", "rewrite": "/dashboard.html" },
+    { "route": "/login", "rewrite": "/login.html" },
+    { "route": "/records", "rewrite": "/records.html" },
+    { "route": "/planned-payments", "rewrite": "/planned-payments.html" },
+    { "route": "/account-access", "rewrite": "/account-access.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Scaffolds Azure Static Web Apps hosting for the web frontend: `staticwebapp.config.json` route rewrites, `web:build`/`web:deploy` npm scripts, and a `frontend-web-deploy.yml` GitHub Actions workflow (deploys on push to `main` via the official `Azure/static-web-apps-deploy@v1` action).
- Externalizes backend CORS allowed origins from hardcoded Java (`WebConfig`) into `app.cors.allowed-origin-patterns` in `application.yaml`, bound via a new `CorsConfigProperties` class — overridable via `APP_CORS_ALLOWEDORIGINPATTERNS` env var on Cloud Run without a rebuild (verified end-to-end locally: override origin allowed, previous default origin correctly rejected).
- Adds the production Static Web Apps origin (`https://jolly-mushroom-06ba64b00.7.azurestaticapps.net`) to the CORS allow-list.
- Corrects `docs/web-sso-and-hosting-plan.md`: actual resources ended up in `eastasia` under a new Pay-As-You-Go subscription (`lazyspender`), not the originally-planned `eastus2`/free-trial subscription — the free trial had already been auto-deleted (exhausted credit, past reactivation grace period) by the time hosting was set up.

## Azure resources created (out of band, not in this diff)
- Subscription: `lazyspender` (Pay-As-You-Go)
- Resource group: `lazyspender-rg` (East Asia)
- Static Web App: `lazyspender-web` (Free tier)
- GitHub secret `AZURE_STATIC_WEB_APPS_API_TOKEN` set for the deploy workflow

## Test plan
- [x] Backend compiles (`./gradlew compileJava`)
- [x] CORS env var override verified locally (curl preflight against override origin vs default origin)
- [ ] Manual GCP Console step (owner: user): add `https://jolly-mushroom-06ba64b00.7.azurestaticapps.net` to Authorized JavaScript origins on the Web OAuth client
- [ ] After merge: verify `frontend-web-deploy.yml` and `backend-deploy.yml` both run successfully and the deployed site can sign in end-to-end