### PR TITLE
Fix dashboard "No accounts configured" on profile switch

### DIFF
--- a/frontend/components/BalanceTrendWidget.tsx
+++ b/frontend/components/BalanceTrendWidget.tsx
@@ -29,16 +29,23 @@ export const BalanceTrendWidget: React.FC = () => {
   const [menuVisible, setMenuVisible] = useState(false);
 
   // Reset the account filter whenever the active profile changes, then
-  // repopulate it from that profile's own accounts once they load.
+  // repopulate it from that profile's own accounts once they load. Tracked
+  // via a ref (not selectedAccounts.length === 0) because delegatedOwner and
+  // user?.accounts can change together in the same render (e.g. cached user
+  // data resolving instantly on profile switch) - splitting this into two
+  // separate effects raced on a stale selectedAccounts closure and could
+  // leave the filter stuck empty, showing "no accounts configured" for an
+  // account that actually has data.
+  const populatedOwnerRef = React.useRef<string | null>(null);
   React.useEffect(() => {
-    setSelectedAccounts([]);
-  }, [delegatedOwner]);
-
-  React.useEffect(() => {
-    if (user?.accounts && selectedAccounts.length === 0) {
-      setSelectedAccounts(user.accounts);
+    if (populatedOwnerRef.current === delegatedOwner) return;
+    if (!user?.accounts) {
+      setSelectedAccounts([]);
+      return;
     }
-  }, [user?.accounts]);
+    setSelectedAccounts(user.accounts);
+    populatedOwnerRef.current = delegatedOwner;
+  }, [delegatedOwner, user?.accounts]);
 
   const { data, isLoading, isFetching, isError, error } = useBalanceTrend(
     {

--- a/frontend/components/ExpenseDistributionWidget.tsx
+++ b/frontend/components/ExpenseDistributionWidget.tsx
@@ -61,19 +61,30 @@ export const ExpenseDistributionWidget: React.FC = () => {
   const [expandedCategory, setExpandedCategory] = useState<string | null>(null);
   const [initialLoadDone, setInitialLoadDone] = useState(false);
 
-  // Reset the account filter and expanded category whenever the active
-  // profile changes, then repopulate accounts from that profile's own list.
+  // Reset the expanded category whenever the active profile changes.
   React.useEffect(() => {
-    setSelectedAccounts([]);
     setExpandedCategory(null);
     setInitialLoadDone(false);
   }, [delegatedOwner]);
 
+  // Reset the account filter whenever the active profile changes, then
+  // repopulate it from that profile's own accounts once they load. Tracked
+  // via a ref (not selectedAccounts.length === 0) because delegatedOwner and
+  // user?.accounts can change together in the same render (e.g. cached user
+  // data resolving instantly on profile switch) - splitting this into two
+  // separate effects raced on a stale selectedAccounts closure and could
+  // leave the filter stuck empty, showing "no accounts configured" for an
+  // account that actually has data.
+  const populatedOwnerRef = React.useRef<string | null>(null);
   React.useEffect(() => {
-    if (user?.accounts && selectedAccounts.length === 0) {
-      setSelectedAccounts(user.accounts);
+    if (populatedOwnerRef.current === delegatedOwner) return;
+    if (!user?.accounts) {
+      setSelectedAccounts([]);
+      return;
     }
-  }, [user?.accounts]);
+    setSelectedAccounts(user.accounts);
+    populatedOwnerRef.current = delegatedOwner;
+  }, [delegatedOwner, user?.accounts]);
 
   const { data, isLoading, isFetching, isError, error } = useExpenseDistribution(
     {


### PR DESCRIPTION
## Summary
- Dashboard widgets (Balance Trend, Expense Distribution) could get stuck showing "No accounts configured" for a delegated/shared account that actually has transactions, while Records showed the same account's data fine.
- Root cause: each widget split account-filter reset (on `delegatedOwner` change) and populate (on `user?.accounts` change) into two separate effects. When both deps changed in the same render (e.g. the new owner's user data already cached), the populate effect read a stale `selectedAccounts` closure from before the reset applied and skipped populating - leaving the filter permanently empty.
- Fix: collapsed reset+populate into a single effect per widget, tracking which owner has been populated via a ref instead of racing on component state.

Closes #76

## Test plan
- [ ] Switch between own account and a delegated/shared account on the dashboard a few times (including switching to the same account twice, since that's what most reliably hits cached-data timing) and confirm Balance Trend / Expense Distribution never get stuck on "No accounts configured" for an account that has transactions.