### PR TITLE
fix(frontend): use DatePickerModal fallback for date picker on web/PWA

### DIFF
--- a/frontend/components/TransactionFormModal.tsx
+++ b/frontend/components/TransactionFormModal.tsx
@@ -3,12 +3,13 @@ import React, { useState } from 'react';
 import {
   Alert,
   Modal,
+  Platform,
   ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
 import { Button, Chip, Divider, IconButton, SegmentedButtons, Surface, Text, TextInput, useTheme } from 'react-native-paper';
-import { TimePickerModal } from 'react-native-paper-dates';
+import { DatePickerModal, TimePickerModal } from 'react-native-paper-dates';
 import { shadows, spacing } from '../config/theme';
 import { useAccessContext } from '../contexts/AccessContext';
 import { useCreateTransaction, useDistinctNotes, useUpdateTransaction } from '../hooks/useTransactions';
@@ -88,6 +89,20 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, on
       return;
     }
 
+    if (!selectedDate) return;
+
+    const currentDate = getSelectedDate();
+    const newDate = new Date(selectedDate);
+    newDate.setHours(currentDate.getHours());
+    newDate.setMinutes(currentDate.getMinutes());
+    newDate.setSeconds(currentDate.getSeconds());
+    newDate.setMilliseconds(currentDate.getMilliseconds());
+
+    setFormData({ ...formData, date: newDate.toISOString() });
+    setDatePickerVisible(false);
+  };
+
+  const handleDateConfirm = ({ date: selectedDate }: { date?: Date }) => {
     if (!selectedDate) return;
 
     const currentDate = getSelectedDate();
@@ -315,7 +330,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, on
                         disabled={isPending}
                         icon="calendar"
                         contentStyle={styles.dateTimeButtonContent}
-                        style={[styles.dateTimeButton, { flex: 1.5 }]}
+                        style={[styles.dateTimeButton, styles.dateTimeButtonHalf]}
                         theme={{
                           colors: {
                             outline: 'transparent',
@@ -330,7 +345,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, on
                         disabled={isPending}
                         icon="clock-outline"
                         contentStyle={styles.dateTimeButtonContent}
-                        style={[styles.dateTimeButton, { flex: 1 }]}
+                        style={[styles.dateTimeButton, styles.dateTimeButtonHalf]}
                         theme={{
                           colors: {
                             outline: 'transparent',
@@ -384,15 +399,27 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ visible, on
         </View>
       </Modal>
 
-      {datePickerVisible && (
-        <DateTimePicker
-          value={getSelectedDate()}
-          mode="date"
-          display="default"
-          onChange={handleDateChange}
-          themeVariant="light"
-          accentColor={theme.colors.primary}
+      {Platform.OS === 'web' ? (
+        <DatePickerModal
+          locale="en"
+          mode="single"
+          visible={datePickerVisible}
+          onDismiss={() => setDatePickerVisible(false)}
+          date={getSelectedDate()}
+          onConfirm={handleDateConfirm}
+          presentationStyle="pageSheet"
         />
+      ) : (
+        datePickerVisible && (
+          <DateTimePicker
+            value={getSelectedDate()}
+            mode="date"
+            display="default"
+            onChange={handleDateChange}
+            themeVariant="light"
+            accentColor={theme.colors.primary}
+          />
+        )
       )}
 
       <TimePickerModal
@@ -490,6 +517,9 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     backgroundColor: '#F8F9FA',
     ...shadows.sm,
+  },
+  dateTimeButtonHalf: {
+    flex: 1,
   },
   dateTimeButtonContent: {
     justifyContent: 'center',

--- a/frontend/components/planned-payments/PlannedPaymentFormModal.tsx
+++ b/frontend/components/planned-payments/PlannedPaymentFormModal.tsx
@@ -3,11 +3,13 @@ import React, { useState } from 'react';
 import {
   Alert,
   Modal,
+  Platform,
   ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
 import { Button, Checkbox, Chip, Divider, IconButton, SegmentedButtons, Surface, Text, TextInput, useTheme } from 'react-native-paper';
+import { DatePickerModal } from 'react-native-paper-dates';
 import { shadows, spacing } from '../../config/theme';
 import { useAccessContext } from '../../contexts/AccessContext';
 import { useCreatePlannedPayment, useUpdatePlannedPayment } from '../../hooks/usePlannedPayments';
@@ -85,6 +87,17 @@ const PlannedPaymentFormModal: React.FC<PlannedPaymentFormModalProps> = ({ visib
       return;
     }
 
+    if (!selectedDate) return;
+
+    setFormData({
+      ...formData,
+      startDate: selectedDate.toISOString(),
+      recurrenceValue: selectedDate.getDate().toString()
+    });
+    setDatePickerVisible(false);
+  };
+
+  const handleDateConfirm = ({ date: selectedDate }: { date?: Date }) => {
     if (!selectedDate) return;
 
     setFormData({
@@ -420,15 +433,27 @@ const PlannedPaymentFormModal: React.FC<PlannedPaymentFormModalProps> = ({ visib
         </View>
       </Modal>
 
-      {datePickerVisible && (
-        <DateTimePicker
-          value={getSelectedDate()}
-          mode="date"
-          display="default"
-          onChange={handleDateChange}
-          themeVariant="light"
-          accentColor={theme.colors.primary}
+      {Platform.OS === 'web' ? (
+        <DatePickerModal
+          locale="en"
+          mode="single"
+          visible={datePickerVisible}
+          onDismiss={() => setDatePickerVisible(false)}
+          date={getSelectedDate()}
+          onConfirm={handleDateConfirm}
+          presentationStyle="pageSheet"
         />
+      ) : (
+        datePickerVisible && (
+          <DateTimePicker
+            value={getSelectedDate()}
+            mode="date"
+            display="default"
+            onChange={handleDateChange}
+            themeVariant="light"
+            accentColor={theme.colors.primary}
+          />
+        )
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- Native date picker (`@react-native-community/datetimepicker`) has no web implementation and silently no-ops on web, so the date picker stopped working once the app became installable as a PWA on Android/iOS (#75).
- `TransactionFormModal` and `PlannedPaymentFormModal` now render the native picker only on `Platform.OS !== 'web'`, falling back to `react-native-paper-dates`' `DatePickerModal` on web.
- Also fixes the date/time buttons in `TransactionFormModal` being unevenly sized (`flex: 1.5` / `flex: 1`), which truncated the time button — both now split 50/50.

Fixes #81

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (no new errors)
- [ ] Manual check on an Android/iOS device (installed PWA and browser) that the date picker opens and buttons are evenly sized