### PR TITLE
fix(frontend): prioritize scroll over slide-to-delete on records screen

### DIFF
--- a/frontend/app/records.tsx
+++ b/frontend/app/records.tsx
@@ -1,7 +1,8 @@
 import { CreateTransactionRequest } from "@/services/transaction.service";
 import { useIsFocused } from "@react-navigation/native";
 import { useMemo, useState } from "react";
-import { FlatList, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+import { FlatList } from "react-native-gesture-handler";
 import { ActivityIndicator, Button, FAB, Text, useTheme } from "react-native-paper";
 import SwipeableTransactionItem from "../components/SwipeableTransactionItem";
 import TransactionFormModal from "../components/TransactionFormModal";

--- a/frontend/components/SwipeableTransactionItem.tsx
+++ b/frontend/components/SwipeableTransactionItem.tsx
@@ -69,12 +69,9 @@ export default function SwipeableTransactionItem({ transaction, onPress, onDelet
       <ReanimatedSwipeable
         ref={swipeableRef}
         renderRightActions={RightAction}
-        onEnded={() => console.log('onEnded')}
-        onFailed={() => console.log('onFailed')}
-        onActivated={() => console.log('onActivated')}
-        onSwipeableClose={() => console.log('onSwipeableClose')}
-        onSwipeableOpen={() => handleOnDelete(transaction.id)}
-        onBegan={() => console.log('onBegan')}>
+        dragOffsetFromRightEdge={20}
+        dragOffsetFromLeftEdge={10000}
+        onSwipeableOpen={() => handleOnDelete(transaction.id)}>
         <GestureDetector gesture={singleTapGesture()}>
           <Surface style={styles.surface} elevation={1}>
             <List.Item


### PR DESCRIPTION
## Summary
- List scroll and row swipe-to-delete on the records screen were arbitrated by two uncoordinated touch systems (`FlatList` from `react-native` vs. `ReanimatedSwipeable`'s native pan gesture), so a scroll touch with slight horizontal wobble could cross the 10px activation threshold and hijack the gesture into a swipe instead of scrolling.
- Import `FlatList` from `react-native-gesture-handler` in `records.tsx` so both gestures share the same native arbitration system.
- Widen `dragOffsetFromRightEdge` to 20px on `SwipeableTransactionItem` so delete-swipe only activates on a decisively horizontal drag, and set `dragOffsetFromLeftEdge` very high since there's no left action to guard against.

Closes #87

## Test plan
- [x] `npm run lint` — 0 errors, only pre-existing warnings unrelated to changed files
- [ ] Manual verification of scroll vs. swipe feel on the records screen (not done in this session — local dev session had no authenticated data to test against; verify after deploy or with a signed-in local session)