### PR TITLE
fix(frontend): fix invisible due-date/progress text on planned payment items

### DIFF
--- a/frontend/components/planned-payments/PlannedPaymentItem.tsx
+++ b/frontend/components/planned-payments/PlannedPaymentItem.tsx
@@ -129,11 +129,11 @@ export default function PlannedPaymentItem({
                         </Text>
                       ) : null}
                       <View style={styles.metaRow}>
-                        <Text variant="labelSmall" style={{ color: theme.colors.outline }}>
+                        <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
                           {formatDueDate(plannedPayment.nextDueDate)}
                         </Text>
                         <Text variant="labelSmall" style={styles.separator}>•</Text>
-                        <Text variant="labelSmall" style={{ color: theme.colors.outline }}>
+                        <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
                           {getProgressText()}
                         </Text>
                       </View>


### PR DESCRIPTION
## Summary
- Each planned payment list item's due-date and progress labels (\`Due today • 2/5\`) were rendering fully transparent, because they used \`theme.colors.outline\`, which is set to \`'transparent'\` in \`config/theme.ts\` for stripping borders elsewhere (Chips/Buttons/SegmentedButtons) — not intended as a text color.
- Only the separator bullet stayed visible (hardcoded \`#999\`), which read as a stray \".\" — matches the reported bug where the detail card showed correct progress but the list item didn't.
- Switched both to \`theme.colors.onSurfaceVariant\`, the token already used correctly for the note text in the same component and throughout \`PlannedPaymentDetailModal\`.

Fixes #88

## Test plan
- [ ] Run frontend locally against local backend, open Planned Payments list, confirm due date + progress text is visible on each item
- [ ] Confirm detail modal still shows correct progress (regression check)
- [ ] Verify no other list items/styling regressed