### PR TITLE
fix(frontend): stop swipe gesture from blocking list scroll (records + planned payments)

### DIFF
--- a/frontend/app/planned-payments.tsx
+++ b/frontend/app/planned-payments.tsx
@@ -1,6 +1,7 @@
 import { useIsFocused } from "@react-navigation/native";
 import { useMemo, useState } from "react";
-import { FlatList, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+import { FlatList } from "react-native-gesture-handler";
 import { ActivityIndicator, Button, FAB, Text, useTheme } from "react-native-paper";
 import PlannedPaymentDetailModal from "../components/planned-payments/PlannedPaymentDetailModal";
 import PlannedPaymentFormModal from "../components/planned-payments/PlannedPaymentFormModal";

--- a/frontend/components/SwipeableTransactionItem.tsx
+++ b/frontend/components/SwipeableTransactionItem.tsx
@@ -72,7 +72,7 @@ export default function SwipeableTransactionItem({ transaction, onPress, onDelet
         dragOffsetFromRightEdge={20}
         dragOffsetFromLeftEdge={10000}
         onSwipeableOpen={() => handleOnDelete(transaction.id)}>
-        <GestureDetector gesture={singleTapGesture()}>
+        <GestureDetector gesture={singleTapGesture()} touchAction="pan-y">
           <Surface style={styles.surface} elevation={1}>
             <List.Item
               title={transaction.category}

--- a/frontend/components/planned-payments/PlannedPaymentItem.tsx
+++ b/frontend/components/planned-payments/PlannedPaymentItem.tsx
@@ -114,6 +114,8 @@ export default function PlannedPaymentItem({
       <ReanimatedSwipeable
         ref={swipeableRef}
         renderRightActions={RightAction}
+        dragOffsetFromRightEdge={20}
+        dragOffsetFromLeftEdge={10000}
         onSwipeableOpen={() => handleOnDelete(plannedPayment.id)}>
         <Surface style={styles.surface} elevation={1}>
           <View style={styles.container}>

--- a/frontend/components/planned-payments/PlannedPaymentItem.tsx
+++ b/frontend/components/planned-payments/PlannedPaymentItem.tsx
@@ -119,7 +119,7 @@ export default function PlannedPaymentItem({
         onSwipeableOpen={() => handleOnDelete(plannedPayment.id)}>
         <Surface style={styles.surface} elevation={1}>
           <View style={styles.container}>
-            <GestureDetector gesture={singleTapGesture()}>
+            <GestureDetector gesture={singleTapGesture()} touchAction="pan-y">
               <View style={styles.mainContent}>
                 <List.Item
                   title={plannedPayment.category}


### PR DESCRIPTION
## Summary
- Original diagnosis in #87/#89 was incomplete: that fix tuned native (iOS/Android) pan-gesture arbitration (`FlatList` import, `dragOffsetFromRightEdge`/`dragOffsetFromLeftEdge`) but missed the actual cause of the reported symptom on web — confirmed still broken on the records screen after #89 merged, and would have affected planned payments the same way if only pattern-copied.
- **Real root cause**: `react-native-gesture-handler`'s `GestureDetector` defaults `touchAction` to `"none"` on web, which sets CSS `touch-action: none` on its DOM node. `ReanimatedSwipeable` sets `touchAction="pan-y"` on its own two internal `GestureDetector`s, but `SwipeableTransactionItem`/`PlannedPaymentItem` each wrap the card content in an additional, innermost `GestureDetector` (for tap-to-open) that never set `touchAction`. Being the innermost element actually receiving the touch, its `none` default wins over the ancestors' `pan-y` and blocks native vertical scroll for any touch starting on the card — matching "works outside the card, not on it" exactly.
- Set `touchAction="pan-y"` on both tap `GestureDetector`s (records + planned payments) to match Swipeable's own convention.
- Also carries the originally-planned parity fix for planned payments: `FlatList` now imports from `react-native-gesture-handler`, and `dragOffsetFromRightEdge`/`dragOffsetFromLeftEdge` are tuned the same as records, for native-platform gesture arbitration.

Reopens #87
Fixes #91

## Test plan
- [ ] On web, confirm a vertical drag starting on top of a card scrolls the list on both Records and Planned Payments
- [ ] Confirm a decisively horizontal drag on a card still reveals delete on both screens
- [ ] Confirm tap-to-open still works on both screens