### PR TITLE
feat: debt trend widget frontend (#65)

### DIFF
--- a/backend/src/main/java/com/lazyspender/backend/dto/DebtCategoryAmount.java
+++ b/backend/src/main/java/com/lazyspender/backend/dto/DebtCategoryAmount.java
@@ -1,4 +1,11 @@
 package com.lazyspender.backend.dto;
 
-public record DebtCategoryAmount(String category, double amount) {
+/**
+ * category here is actually the debt's display label (the payment's note, falling
+ * back to its planned-payment category when no note is set - see
+ * DebtTrendService.debtLabel). originalCategory is always the planned payment's
+ * true category (e.g. "Car Loan"), kept alongside so the frontend can show it as
+ * a chip next to the note without losing which category a debt belongs to.
+ */
+public record DebtCategoryAmount(String category, double amount, String originalCategory) {
 }

--- a/backend/src/main/java/com/lazyspender/backend/service/DebtTrendService.java
+++ b/backend/src/main/java/com/lazyspender/backend/service/DebtTrendService.java
@@ -97,16 +97,23 @@ public class DebtTrendService {
             ZonedDateTime nextBucketStart = getNextBucketStart(bucketStart, aggregate);
             Instant bucketEndExclusive = nextBucketStart.toInstant();
 
-            Map<String, Double> amountByCategory = new HashMap<>();
+            Map<String, Double> amountByLabel = new HashMap<>();
+            // First category seen for a label wins; in practice a note uniquely
+            // identifies one debt, so this only matters if two payments happen to
+            // share identical note text.
+            Map<String, String> categoryByLabel = new HashMap<>();
             for (PlannedPayment payment : plannedPayments) {
                 double amount = calculateOutstandingAmount(payment, confirmedDatesByPlannedPaymentId, bucketEndExclusive);
                 if (amount > 0) {
-                    amountByCategory.merge(payment.getCategory(), amount, Double::sum);
+                    String label = debtLabel(payment);
+                    amountByLabel.merge(label, amount, Double::sum);
+                    categoryByLabel.putIfAbsent(label, payment.getCategory());
                 }
             }
 
-            List<DebtCategoryAmount> categories = amountByCategory.entrySet().stream()
-                    .map(entry -> new DebtCategoryAmount(entry.getKey(), entry.getValue()))
+            List<DebtCategoryAmount> categories = amountByLabel.entrySet().stream()
+                    .map(entry -> new DebtCategoryAmount(entry.getKey(), entry.getValue(),
+                            categoryByLabel.get(entry.getKey())))
                     .toList();
 
             double totalDebt = categories.stream().mapToDouble(DebtCategoryAmount::amount).sum();
@@ -118,6 +125,17 @@ public class DebtTrendService {
         }
 
         return dataPoints;
+    }
+
+    /**
+     * Debts are broken down per payment note (e.g. "Car loan"), since the note
+     * identifies the individual debt; category is only a fallback for payments
+     * saved without a note. The DebtCategoryAmount.category field carries this
+     * label on the wire.
+     */
+    private String debtLabel(PlannedPayment payment) {
+        String note = payment.getNote();
+        return (note != null && !note.isBlank()) ? note : payment.getCategory();
     }
 
     /**

--- a/backend/src/test/java/com/lazyspender/backend/service/DebtTrendServiceTest.java
+++ b/backend/src/test/java/com/lazyspender/backend/service/DebtTrendServiceTest.java
@@ -102,7 +102,7 @@ class DebtTrendServiceTest {
                 .containsExactly("Jan 2026", "Feb 2026", "Mar 2026");
         assertThat(response.dataPoints()).extracting(DebtTrendDataPoint::totalDebt)
                 .containsExactly(1000.0, 1000.0, 1000.0);
-        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Rent", 1000));
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Rent", 1000, "Rent"));
         assertThat(response.totalDebt()).isEqualTo(1000.0);
         assertThat(response.currency()).isEqualTo("PHP");
     }
@@ -149,7 +149,7 @@ class DebtTrendServiceTest {
                 LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
 
         assertThat(response.dataPoints()).hasSize(1);
-        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 200));
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 200, "Utilities"));
         assertThat(response.totalDebt()).isEqualTo(200.0);
     }
 
@@ -175,8 +175,37 @@ class DebtTrendServiceTest {
         DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
                 LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
 
-        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 500));
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 500, "Utilities"));
         assertThat(response.totalDebt()).isEqualTo(500.0);
+    }
+
+    @Test
+    void paymentsAreGroupedByNoteWhenPresent() {
+        PlannedPayment carLoan = neverEndingPayment("p1", "Loan", 200, LocalDate.of(2025, 12, 1));
+        carLoan.setNote("Car loan");
+        PlannedPayment houseLoan = neverEndingPayment("p2", "Loan", 300, LocalDate.of(2025, 12, 1));
+        houseLoan.setNote("House loan");
+        stubRepositories(List.of(carLoan, houseLoan), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints().get(0).categories()).containsExactlyInAnyOrder(
+                new DebtCategoryAmount("Car loan", 200, "Loan"),
+                new DebtCategoryAmount("House loan", 300, "Loan"));
+        assertThat(response.totalDebt()).isEqualTo(500.0);
+    }
+
+    @Test
+    void paymentWithBlankNoteFallsBackToCategoryLabel() {
+        PlannedPayment payment = neverEndingPayment("p1", "Utilities", 200, LocalDate.of(2025, 12, 1));
+        payment.setNote("   ");
+        stubRepositories(List.of(payment), List.of());
+
+        DebtTrendResponse response = debtTrendService.getDebtTrend(OWNER, LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31), DebtAggregation.MONTHLY);
+
+        assertThat(response.dataPoints().get(0).categories()).containsExactly(new DebtCategoryAmount("Utilities", 200, "Utilities"));
     }
 
     @Test

--- a/frontend/app/dashboard.tsx
+++ b/frontend/app/dashboard.tsx
@@ -2,6 +2,7 @@ import { ScrollView, StyleSheet, View } from "react-native";
 import { useTheme } from "react-native-paper";
 import { spacing } from "../config/theme";
 import { BalanceTrendWidget } from "../components/BalanceTrendWidget";
+import { DebtTrendWidget } from "../components/DebtTrendWidget";
 import { ExpenseDistributionWidget } from "../components/ExpenseDistributionWidget";
 
 export default function Dashboard() {
@@ -12,6 +13,7 @@ export default function Dashboard() {
       <View style={styles.content}>
         <BalanceTrendWidget />
         <ExpenseDistributionWidget />
+        <DebtTrendWidget />
       </View>
     </ScrollView>
   );

--- a/frontend/components/BalanceTrendWidget.tsx
+++ b/frontend/components/BalanceTrendWidget.tsx
@@ -69,6 +69,16 @@ export const BalanceTrendWidget: React.FC = () => {
     });
   };
 
+  // The backend returns zero-valued data points even when the owner has no
+  // transactions at all, so an all-zero series means "no data" - showing a
+  // flat line at PHP 0.00 would be misleading.
+  const hasBalanceData = useMemo(
+    () =>
+      (data?.dataPoints || []).some((point) => point.balance !== 0) ||
+      (data?.totalBalance ?? 0) !== 0,
+    [data?.dataPoints, data?.totalBalance]
+  );
+
   // Prepare chart data with proper spacing to prevent label cutoff
   const { chartData, chartSpacing, shouldScroll, availableWidth } = useMemo(() => {
     if (!data?.dataPoints || data.dataPoints.length === 0) {
@@ -173,7 +183,7 @@ export const BalanceTrendWidget: React.FC = () => {
         </Text>
 
         {/* Total Balance */}
-        {chartData.length > 0 && (
+        {hasBalanceData && (
           <View style={styles.balanceContainer}>
             <Text variant="headlineLarge" style={styles.balanceAmount}>
               {data?.currency || 'PHP'} {data?.totalBalance.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
@@ -185,7 +195,7 @@ export const BalanceTrendWidget: React.FC = () => {
         )}
 
         {/* Line Chart */}
-        {chartData.length > 0 ? (
+        {hasBalanceData && chartData.length > 0 ? (
           <View style={styles.chartContainer}>
             <LineChart
               data={chartData}

--- a/frontend/components/DebtTrendWidget.tsx
+++ b/frontend/components/DebtTrendWidget.tsx
@@ -1,17 +1,16 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { BarChart } from 'react-native-gifted-charts';
-import { ActivityIndicator, Card, Divider, IconButton, Menu, SegmentedButtons, Text, useTheme } from 'react-native-paper';
-import { customTheme, spacing } from '../config/theme';
+import { ActivityIndicator, Card, Divider, IconButton, Menu, Text, useTheme } from 'react-native-paper';
+import { customColors, customTheme, spacing } from '../config/theme';
 import { useAccessContext } from '../contexts/AccessContext';
 import { useDebtTrend } from '../hooks/useDebtTrend';
 import { DebtAggregation } from '../types/debtTrend';
-import { getCategoryColor } from '../utils/categoryColors';
 
 interface RangePreset {
   key: string;
   label: string;
-  count: number; // number of months/years back to include, per the active aggregation
+  count: number; // number of months back to include
 }
 
 const MONTHLY_PRESETS: RangePreset[] = [
@@ -19,13 +18,35 @@ const MONTHLY_PRESETS: RangePreset[] = [
   { key: 'M12', label: 'Last 12 months', count: 12 },
 ];
 
-const YEARLY_PRESETS: RangePreset[] = [
-  { key: 'Y3', label: 'Last 3 years', count: 3 },
-  { key: 'Y5', label: 'Last 5 years', count: 5 },
-];
+// gifted-charts reserves this width for y-axis labels when yAxisLabelWidth
+// isn't overridden; needed to anchor the segment tooltip to its bar.
+const Y_AXIS_LABEL_WIDTH = 35;
+const TOOLTIP_WIDTH = 150;
 
-const getPresetsForAggregate = (aggregate: DebtAggregation): RangePreset[] =>
-  aggregate === DebtAggregation.MONTHLY ? MONTHLY_PRESETS : YEARLY_PRESETS;
+// The backend labels each debt by its planned payment's note (free text), so
+// colors can't come from the fixed category map - assign palette colors per
+// label, largest debt first.
+const SERIES_PALETTE = [
+  customColors.iconForegrounds.blue,
+  customColors.iconForegrounds.orange,
+  customColors.iconForegrounds.green,
+  customColors.iconForegrounds.purple,
+  customColors.iconForegrounds.pink,
+  customColors.iconForegrounds.teal,
+  customColors.iconForegrounds.amber,
+  customColors.iconForegrounds.indigo,
+  customColors.iconForegrounds.deepOrange,
+  customColors.iconForegrounds.cyan,
+  customColors.iconForegrounds.magenta,
+  customColors.iconForegrounds.lightGreen,
+];
+const FALLBACK_SERIES_COLOR = customColors.iconForegrounds.gray;
+
+interface TappedSegment {
+  monthIndex: number;
+  category: string;
+  amount: number;
+}
 
 const formatLocalDate = (date: Date): string => {
   const year = date.getFullYear();
@@ -34,96 +55,197 @@ const formatLocalDate = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
-const computeDateRange = (aggregate: DebtAggregation, preset: RangePreset): { from: string; to: string } => {
+const computeDateRange = (preset: RangePreset): { from: string; to: string } => {
   const today = new Date();
   const to = formatLocalDate(today);
 
   const from = new Date(today);
-  if (aggregate === DebtAggregation.MONTHLY) {
-    from.setDate(1);
-    from.setMonth(from.getMonth() - (preset.count - 1));
-  } else {
-    from.setMonth(0, 1);
-    from.setFullYear(from.getFullYear() - (preset.count - 1));
-  }
+  from.setDate(1);
+  from.setMonth(from.getMonth() - (preset.count - 1));
 
   return { from: formatLocalDate(from), to };
 };
+
+const formatAmount = (amount: number): string =>
+  amount.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+// Debt labels come from free-text payment notes, so normalize casing for
+// display (e.g. "car amortization" -> "Car Amortization").
+const toTitleCase = (label: string): string =>
+  label.replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+
+const CHART_HEIGHT = 250;
+// Ensure every debt segment renders at least this tall so small debts stay
+// visible and tappable next to large ones (e.g. an amortization). Only the
+// rendered height is padded - tooltips and the breakdown show real amounts.
+const MIN_SEGMENT_PX = 6;
 
 export const DebtTrendWidget: React.FC = () => {
   const theme = useTheme();
   const { delegatedOwner } = useAccessContext();
 
-  const [aggregate, setAggregate] = useState<DebtAggregation>(DebtAggregation.MONTHLY);
   const [selectedPresetKey, setSelectedPresetKey] = useState<string>(MONTHLY_PRESETS[0].key);
   const [menuVisible, setMenuVisible] = useState(false);
+  const [selectedMonthIndex, setSelectedMonthIndex] = useState<number | null>(null);
+  const [tappedSegment, setTappedSegment] = useState<TappedSegment | null>(null);
 
-  const presets = useMemo(() => getPresetsForAggregate(aggregate), [aggregate]);
+  const selectedPreset =
+    MONTHLY_PRESETS.find((p) => p.key === selectedPresetKey) || MONTHLY_PRESETS[0];
 
-  // Reset the range preset to the new aggregation's default whenever the
-  // toggle changes, since month-scoped and year-scoped presets aren't interchangeable.
-  useEffect(() => {
-    setSelectedPresetKey(presets[0].key);
-  }, [presets]);
-
-  const selectedPreset = presets.find((p) => p.key === selectedPresetKey) || presets[0];
-
-  const { from, to } = useMemo(
-    () => computeDateRange(aggregate, selectedPreset),
-    [aggregate, selectedPreset]
-  );
+  const { from, to } = useMemo(() => computeDateRange(selectedPreset), [selectedPreset]);
 
   const { data, isLoading, isFetching, isError, error } = useDebtTrend(
-    { from, to, aggregate },
+    { owner: delegatedOwner, from, to, aggregate: DebtAggregation.MONTHLY },
     { enabled: !!delegatedOwner }
   );
+
+  const pointCount = data?.dataPoints?.length ?? 0;
+
+  // Default the always-visible breakdown to the most recent month, and drop
+  // any tooltip/selection pointing into a previous range or profile.
+  useEffect(() => {
+    setSelectedMonthIndex(pointCount > 0 ? pointCount - 1 : null);
+    setTappedSegment(null);
+  }, [pointCount, from, to, delegatedOwner]);
 
   const hasDebt = useMemo(
     () => (data?.dataPoints || []).some((point) => point.totalDebt > 0),
     [data?.dataPoints]
   );
 
-  const legendItems = useMemo(() => {
-    if (!data?.dataPoints) return [];
+  // Series are ordered by their total debt across the whole period,
+  // descending, so the biggest debt sits at the bottom of every stack and
+  // first in the legend/breakdown. Colors follow the same ranking.
+  const { legendItems, colorByLabel, rankByLabel } = useMemo(() => {
+    const colorByLabel = new Map<string, string>();
+    const rankByLabel = new Map<string, number>();
+    if (!data?.dataPoints) return { legendItems: [], colorByLabel, rankByLabel };
 
-    const totalsByCategory = new Map<string, number>();
+    const totalsByLabel = new Map<string, number>();
     for (const point of data.dataPoints) {
       for (const category of point.categories) {
-        totalsByCategory.set(category.category, (totalsByCategory.get(category.category) || 0) + category.amount);
+        totalsByLabel.set(category.category, (totalsByLabel.get(category.category) || 0) + category.amount);
       }
     }
 
-    return Array.from(totalsByCategory.entries())
+    const ordered = Array.from(totalsByLabel.entries())
       .filter(([, amount]) => amount > 0)
-      .sort(([, a], [, b]) => b - a)
-      .map(([category]) => ({ category, color: getCategoryColor(category) }));
+      .sort(([, a], [, b]) => b - a);
+
+    ordered.forEach(([label], index) => {
+      colorByLabel.set(label, SERIES_PALETTE[index % SERIES_PALETTE.length]);
+      rankByLabel.set(label, index);
+    });
+
+    return {
+      legendItems: ordered.map(([label]) => ({
+        category: label,
+        color: colorByLabel.get(label) || FALLBACK_SERIES_COLOR,
+      })),
+      colorByLabel,
+      rankByLabel,
+    };
   }, [data?.dataPoints]);
 
-  const { chartData, chartSpacing, availableWidth } = useMemo(() => {
+  const byRank = useCallback(
+    (a: { category: string }, b: { category: string }) =>
+      (rankByLabel.get(a.category) ?? Number.MAX_SAFE_INTEGER) -
+      (rankByLabel.get(b.category) ?? Number.MAX_SAFE_INTEGER),
+    [rankByLabel]
+  );
+
+  const { chartData, barWidth, chartSpacing, availableWidth } = useMemo(() => {
     if (!data?.dataPoints || data.dataPoints.length === 0) {
-      return { chartData: [], chartSpacing: 60, availableWidth: 0 };
+      return { chartData: [], barWidth: 22, chartSpacing: 16, availableWidth: 0 };
     }
 
     const points = data.dataPoints;
     const totalPoints = points.length;
     const screenWidth = Dimensions.get('window').width;
-    const MIN_SPACING = 50;
     const availableWidth = screenWidth - 64 - 40;
-    const calculatedSpacing = totalPoints > 1 ? availableWidth / (totalPoints - 1) : availableWidth;
-    const spacing = Math.max(MIN_SPACING, calculatedSpacing);
+
+    // Split the available width across all months so the chart never
+    // overflows, capping bar width and gap so wide screens don't stretch
+    // the bars apart.
+    const perPoint = availableWidth / totalPoints;
+    const barWidth = Math.min(28, Math.max(12, Math.round(perPoint * 0.45)));
+    const chartSpacing = Math.min(36, Math.max(10, Math.round(perPoint - barWidth)));
+
+    // Smallest value a segment may render as, derived from the y-axis scale,
+    // so no debt collapses below MIN_SEGMENT_PX on screen.
+    const yMax = data.yAxisConfig?.maxValue || 1;
+    const minSegmentValue = (yMax * MIN_SEGMENT_PX) / CHART_HEIGHT;
+
+    // Each bar's total height stays truthful to the y-axis, but the height is
+    // distributed among that month's debts by sqrt(amount) instead of
+    // linearly. This compresses a dominant debt (e.g. an amortization) and
+    // expands the small ones, so an 8000 debt reads clearly bigger than a 180
+    // one. Real amounts still come from the tooltip and breakdown panel.
+    const buildStacks = (point: (typeof points)[number], index: number) => {
+      const positives = [...point.categories]
+        .filter((category) => category.amount > 0)
+        .sort(byRank);
+
+      if (positives.length === 0) {
+        return [{ value: 0, color: 'transparent' }];
+      }
+
+      const total = positives.reduce((sum, category) => sum + category.amount, 0);
+      const weights = positives.map((category) => Math.sqrt(category.amount));
+      const weightSum = weights.reduce((sum, weight) => sum + weight, 0);
+
+      // Floor can't exceed an even split, or floored segments would overflow
+      // the bar's true total.
+      const floorValue = Math.min(minSegmentValue, total / positives.length);
+      const isFloored = weights.map((weight) => (total * weight) / weightSum < floorValue);
+      const flooredSum = isFloored.filter(Boolean).length * floorValue;
+      const freeWeightSum = weights.reduce((sum, weight, i) => (isFloored[i] ? sum : sum + weight), 0);
+
+      return positives.map((category, i) => ({
+        value: isFloored[i]
+          ? floorValue
+          : ((total - flooredSum) * weights[i]) / freeWeightSum,
+        color: colorByLabel.get(category.category) || FALLBACK_SERIES_COLOR,
+        // Tapping a segment selects the month for the breakdown panel and
+        // shows a tooltip with just that category's amount (toggles off on
+        // a second tap of the same segment).
+        onPress: () => {
+          setSelectedMonthIndex(index);
+          setTappedSegment((prev) =>
+            prev && prev.monthIndex === index && prev.category === category.category
+              ? null
+              : { monthIndex: index, category: category.category, amount: category.amount }
+          );
+        },
+      }));
+    };
 
     return {
-      chartData: points.map((point) => ({
+      chartData: points.map((point, index) => ({
         label: point.label,
-        stacks: point.categories.map((category) => ({
-          value: category.amount,
-          color: getCategoryColor(category.category),
-        })),
+        stacks: buildStacks(point, index),
       })),
-      chartSpacing: spacing,
+      barWidth,
+      chartSpacing,
       availableWidth,
     };
-  }, [data?.dataPoints]);
+  }, [data?.dataPoints, data?.yAxisConfig?.maxValue, colorByLabel, byRank]);
+
+  const selectedPoint =
+    selectedMonthIndex !== null ? data?.dataPoints?.[selectedMonthIndex] : undefined;
+
+  const tooltipLeft = useMemo(() => {
+    if (!tappedSegment) return 0;
+    const anchorX =
+      Y_AXIS_LABEL_WIDTH +
+      chartSpacing +
+      tappedSegment.monthIndex * (barWidth + chartSpacing) +
+      barWidth / 2;
+    return Math.min(
+      Math.max(anchorX - TOOLTIP_WIDTH / 2, 0),
+      Math.max(availableWidth - TOOLTIP_WIDTH, 0)
+    );
+  }, [tappedSegment, barWidth, chartSpacing, availableWidth]);
 
   if (isLoading) {
     return (
@@ -170,7 +292,7 @@ export const DebtTrendWidget: React.FC = () => {
             }
             anchorPosition="bottom"
           >
-            {presets.map((option) => (
+            {MONTHLY_PRESETS.map((option) => (
               <Menu.Item
                 key={option.key}
                 onPress={() => {
@@ -185,16 +307,6 @@ export const DebtTrendWidget: React.FC = () => {
           </Menu>
         </View>
 
-        <SegmentedButtons
-          value={aggregate}
-          onValueChange={(value) => setAggregate(value as DebtAggregation)}
-          buttons={[
-            { value: DebtAggregation.MONTHLY, label: 'Monthly', showSelectedCheck: true },
-            { value: DebtAggregation.YEARLY, label: 'Yearly', showSelectedCheck: true },
-          ]}
-          style={styles.segmentedButtons}
-        />
-
         <Text variant="bodySmall" style={styles.periodLabel}>
           {selectedPreset.label}
         </Text>
@@ -202,7 +314,7 @@ export const DebtTrendWidget: React.FC = () => {
         {hasDebt && (
           <View style={styles.totalContainer}>
             <Text variant="headlineLarge" style={styles.totalAmount}>
-              {data?.currency || 'PHP'} {data?.totalDebt.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+              {data?.currency || 'PHP'} {formatAmount(data?.totalDebt || 0)}
             </Text>
             <Text variant="bodySmall" style={styles.totalLabel}>
               Total Outstanding Debt
@@ -213,34 +325,120 @@ export const DebtTrendWidget: React.FC = () => {
         {hasDebt ? (
           <>
             <View style={styles.chartContainer}>
-              <BarChart
-                data={chartData}
-                width={availableWidth}
-                height={250}
-                spacing={chartSpacing}
-                initialSpacing={30}
-                endSpacing={20}
-                yAxisTextStyle={{ color: theme.colors.onSurface, fontSize: 10 }}
-                xAxisLabelTextStyle={{ color: theme.colors.onSurface, fontSize: 10 }}
-                yAxisThickness={0}
-                xAxisThickness={0}
-                xAxisColor={theme.colors.outline}
-                maxValue={data?.yAxisConfig?.maxValue}
-                stepValue={data?.yAxisConfig?.interval}
-                barBorderRadius={4}
-                isAnimated
-              />
+              <View style={{ width: availableWidth }}>
+                <BarChart
+                  // Remount on range/profile change: gifted-charts' animated
+                  // stacked bars throw when the data length changes in place.
+                  key={`${selectedPresetKey}-${delegatedOwner}`}
+                  stackData={chartData}
+                  width={availableWidth}
+                  height={CHART_HEIGHT}
+                  barWidth={barWidth}
+                  spacing={chartSpacing}
+                  initialSpacing={chartSpacing}
+                  endSpacing={chartSpacing}
+                  yAxisTextStyle={{ color: theme.colors.onSurface, fontSize: 10 }}
+                  xAxisLabelTextStyle={{ color: theme.colors.onSurface, fontSize: 10 }}
+                  yAxisThickness={0}
+                  xAxisThickness={0}
+                  xAxisColor={theme.colors.outline}
+                  maxValue={data?.yAxisConfig?.maxValue}
+                  stepValue={data?.yAxisConfig?.interval}
+                  barBorderRadius={0}
+                  isAnimated
+                />
+                {tappedSegment && (
+                  <View
+                    style={[
+                      styles.tooltip,
+                      { left: tooltipLeft, backgroundColor: theme.colors.inverseSurface },
+                    ]}
+                    pointerEvents="none"
+                  >
+                    <Text
+                      variant="labelMedium"
+                      style={[styles.tooltipText, { color: theme.colors.inverseOnSurface }]}
+                    >
+                      {toTitleCase(tappedSegment.category)}
+                    </Text>
+                    <Text
+                      variant="bodySmall"
+                      style={[styles.tooltipText, { color: theme.colors.inverseOnSurface }]}
+                    >
+                      {data?.currency || 'PHP'} {formatAmount(tappedSegment.amount)}
+                    </Text>
+                  </View>
+                )}
+              </View>
             </View>
             <View style={styles.legendContainer}>
               {legendItems.map((item) => (
                 <View key={item.category} style={styles.legendItem}>
                   <View style={[styles.legendDot, { backgroundColor: item.color }]} />
                   <Text variant="bodySmall" style={styles.legendLabel}>
-                    {item.category}
+                    {toTitleCase(item.category)}
                   </Text>
                 </View>
               ))}
             </View>
+            {selectedPoint && (
+              <View style={styles.breakdownSection}>
+                <Text variant="titleSmall" style={styles.breakdownTitle}>
+                  {selectedPoint.label}
+                </Text>
+                <View style={styles.breakdownRow}>
+                  <Text variant="titleSmall" style={styles.breakdownCategory}>
+                    Total
+                  </Text>
+                  <Text variant="titleSmall" style={styles.breakdownAmount}>
+                    {formatAmount(selectedPoint.totalDebt)}
+                  </Text>
+                </View>
+                <Divider style={styles.breakdownDivider} />
+                {[...selectedPoint.categories]
+                  .filter((category) => category.amount > 0)
+                  .sort(byRank)
+                  .map((category) => (
+                    <View
+                      key={category.category}
+                      style={[
+                        styles.breakdownRow,
+                        styles.breakdownNoteRow,
+                        { borderBottomColor: theme.colors.outlineVariant },
+                      ]}
+                    >
+                      <View style={styles.breakdownNoteInfo}>
+                        <View
+                          style={[
+                            styles.legendDot,
+                            { backgroundColor: colorByLabel.get(category.category) || FALLBACK_SERIES_COLOR },
+                          ]}
+                        />
+                        <Text variant="bodyMedium" style={styles.breakdownNoteLabel} numberOfLines={1}>
+                          {toTitleCase(category.category)}
+                        </Text>
+                        <View
+                          style={[
+                            styles.categoryChip,
+                            { backgroundColor: theme.colors.secondaryContainer },
+                          ]}
+                        >
+                          <Text
+                            variant="labelSmall"
+                            style={[styles.categoryChipText, { color: theme.colors.onSecondaryContainer }]}
+                            numberOfLines={1}
+                          >
+                            {toTitleCase(category.originalCategory)}
+                          </Text>
+                        </View>
+                      </View>
+                      <Text variant="bodyMedium" style={styles.breakdownAmount}>
+                        {formatAmount(category.amount)}
+                      </Text>
+                    </View>
+                  ))}
+              </View>
+            )}
           </>
         ) : (
           <View style={styles.noDataContainer}>
@@ -298,9 +496,6 @@ const styles = StyleSheet.create({
   selectedMenuItem: {
     backgroundColor: customTheme.colors.primaryContainer,
   },
-  segmentedButtons: {
-    marginBottom: spacing.sm,
-  },
   periodLabel: {
     color: customTheme.colors.onSurfaceVariant,
     marginBottom: spacing.md,
@@ -322,6 +517,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: spacing.md,
   },
+  tooltip: {
+    position: 'absolute',
+    top: 0,
+    width: TOOLTIP_WIDTH,
+    alignItems: 'center',
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: customTheme.roundness,
+  },
+  tooltipText: {
+    textAlign: 'center',
+  },
   legendContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -341,6 +548,54 @@ const styles = StyleSheet.create({
   },
   legendLabel: {
     color: customTheme.colors.onSurfaceVariant,
+  },
+  breakdownSection: {
+    marginTop: spacing.md,
+    backgroundColor: customTheme.colors.surfaceVariant,
+    borderRadius: customTheme.roundness,
+    padding: spacing.md,
+  },
+  breakdownTitle: {
+    fontWeight: '600',
+    marginBottom: spacing.xs,
+  },
+  breakdownRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.xs,
+  },
+  breakdownNoteRow: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingVertical: spacing.sm,
+  },
+  breakdownCategory: {
+    flex: 1,
+  },
+  breakdownNoteInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    minWidth: 0,
+    marginRight: spacing.sm,
+  },
+  breakdownNoteLabel: {
+    flexShrink: 1,
+    marginRight: spacing.xs,
+  },
+  categoryChip: {
+    borderRadius: 999,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    flexShrink: 0,
+  },
+  categoryChipText: {
+    fontSize: 11,
+  },
+  breakdownAmount: {
+    fontWeight: '600',
+  },
+  breakdownDivider: {
+    marginVertical: spacing.xs,
   },
   noDataContainer: {
     alignItems: 'center',

--- a/frontend/components/DebtTrendWidget.tsx
+++ b/frontend/components/DebtTrendWidget.tsx
@@ -1,0 +1,355 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Dimensions, StyleSheet, View } from 'react-native';
+import { BarChart } from 'react-native-gifted-charts';
+import { ActivityIndicator, Card, Divider, IconButton, Menu, SegmentedButtons, Text, useTheme } from 'react-native-paper';
+import { customTheme, spacing } from '../config/theme';
+import { useAccessContext } from '../contexts/AccessContext';
+import { useDebtTrend } from '../hooks/useDebtTrend';
+import { DebtAggregation } from '../types/debtTrend';
+import { getCategoryColor } from '../utils/categoryColors';
+
+interface RangePreset {
+  key: string;
+  label: string;
+  count: number; // number of months/years back to include, per the active aggregation
+}
+
+const MONTHLY_PRESETS: RangePreset[] = [
+  { key: 'M6', label: 'Last 6 months', count: 6 },
+  { key: 'M12', label: 'Last 12 months', count: 12 },
+];
+
+const YEARLY_PRESETS: RangePreset[] = [
+  { key: 'Y3', label: 'Last 3 years', count: 3 },
+  { key: 'Y5', label: 'Last 5 years', count: 5 },
+];
+
+const getPresetsForAggregate = (aggregate: DebtAggregation): RangePreset[] =>
+  aggregate === DebtAggregation.MONTHLY ? MONTHLY_PRESETS : YEARLY_PRESETS;
+
+const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const computeDateRange = (aggregate: DebtAggregation, preset: RangePreset): { from: string; to: string } => {
+  const today = new Date();
+  const to = formatLocalDate(today);
+
+  const from = new Date(today);
+  if (aggregate === DebtAggregation.MONTHLY) {
+    from.setDate(1);
+    from.setMonth(from.getMonth() - (preset.count - 1));
+  } else {
+    from.setMonth(0, 1);
+    from.setFullYear(from.getFullYear() - (preset.count - 1));
+  }
+
+  return { from: formatLocalDate(from), to };
+};
+
+export const DebtTrendWidget: React.FC = () => {
+  const theme = useTheme();
+  const { delegatedOwner } = useAccessContext();
+
+  const [aggregate, setAggregate] = useState<DebtAggregation>(DebtAggregation.MONTHLY);
+  const [selectedPresetKey, setSelectedPresetKey] = useState<string>(MONTHLY_PRESETS[0].key);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const presets = useMemo(() => getPresetsForAggregate(aggregate), [aggregate]);
+
+  // Reset the range preset to the new aggregation's default whenever the
+  // toggle changes, since month-scoped and year-scoped presets aren't interchangeable.
+  useEffect(() => {
+    setSelectedPresetKey(presets[0].key);
+  }, [presets]);
+
+  const selectedPreset = presets.find((p) => p.key === selectedPresetKey) || presets[0];
+
+  const { from, to } = useMemo(
+    () => computeDateRange(aggregate, selectedPreset),
+    [aggregate, selectedPreset]
+  );
+
+  const { data, isLoading, isFetching, isError, error } = useDebtTrend(
+    { from, to, aggregate },
+    { enabled: !!delegatedOwner }
+  );
+
+  const hasDebt = useMemo(
+    () => (data?.dataPoints || []).some((point) => point.totalDebt > 0),
+    [data?.dataPoints]
+  );
+
+  const legendItems = useMemo(() => {
+    if (!data?.dataPoints) return [];
+
+    const totalsByCategory = new Map<string, number>();
+    for (const point of data.dataPoints) {
+      for (const category of point.categories) {
+        totalsByCategory.set(category.category, (totalsByCategory.get(category.category) || 0) + category.amount);
+      }
+    }
+
+    return Array.from(totalsByCategory.entries())
+      .filter(([, amount]) => amount > 0)
+      .sort(([, a], [, b]) => b - a)
+      .map(([category]) => ({ category, color: getCategoryColor(category) }));
+  }, [data?.dataPoints]);
+
+  const { chartData, chartSpacing, availableWidth } = useMemo(() => {
+    if (!data?.dataPoints || data.dataPoints.length === 0) {
+      return { chartData: [], chartSpacing: 60, availableWidth: 0 };
+    }
+
+    const points = data.dataPoints;
+    const totalPoints = points.length;
+    const screenWidth = Dimensions.get('window').width;
+    const MIN_SPACING = 50;
+    const availableWidth = screenWidth - 64 - 40;
+    const calculatedSpacing = totalPoints > 1 ? availableWidth / (totalPoints - 1) : availableWidth;
+    const spacing = Math.max(MIN_SPACING, calculatedSpacing);
+
+    return {
+      chartData: points.map((point) => ({
+        label: point.label,
+        stacks: point.categories.map((category) => ({
+          value: category.amount,
+          color: getCategoryColor(category.category),
+        })),
+      })),
+      chartSpacing: spacing,
+      availableWidth,
+    };
+  }, [data?.dataPoints]);
+
+  if (isLoading) {
+    return (
+      <Card style={styles.card} elevation={0}>
+        <Card.Content style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <Text style={styles.loadingText}>Loading debt trend...</Text>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card style={styles.card} elevation={0}>
+        <Card.Content>
+          <Text style={styles.errorText}>Failed to load debt trend</Text>
+          <Text style={styles.errorDetails}>{error?.message}</Text>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  return (
+    <Card style={styles.card} elevation={0}>
+      <Card.Content>
+        <View style={styles.header}>
+          <View style={styles.titleRow}>
+            <Text variant="titleLarge" style={styles.title}>
+              Debt Trend
+            </Text>
+            {isFetching && <ActivityIndicator size="small" style={styles.titleSpinner} />}
+          </View>
+          <Menu
+            visible={menuVisible}
+            onDismiss={() => setMenuVisible(false)}
+            anchor={
+              <IconButton
+                icon="dots-vertical"
+                size={24}
+                onPress={() => setMenuVisible((prev) => !prev)}
+                style={styles.menuButton}
+              />
+            }
+            anchorPosition="bottom"
+          >
+            {presets.map((option) => (
+              <Menu.Item
+                key={option.key}
+                onPress={() => {
+                  setSelectedPresetKey(option.key);
+                  setTimeout(() => setMenuVisible(false), 1);
+                }}
+                title={option.label}
+                leadingIcon={selectedPresetKey === option.key ? 'check' : undefined}
+                style={selectedPresetKey === option.key ? styles.selectedMenuItem : undefined}
+              />
+            ))}
+          </Menu>
+        </View>
+
+        <SegmentedButtons
+          value={aggregate}
+          onValueChange={(value) => setAggregate(value as DebtAggregation)}
+          buttons={[
+            { value: DebtAggregation.MONTHLY, label: 'Monthly', showSelectedCheck: true },
+            { value: DebtAggregation.YEARLY, label: 'Yearly', showSelectedCheck: true },
+          ]}
+          style={styles.segmentedButtons}
+        />
+
+        <Text variant="bodySmall" style={styles.periodLabel}>
+          {selectedPreset.label}
+        </Text>
+
+        {hasDebt && (
+          <View style={styles.totalContainer}>
+            <Text variant="headlineLarge" style={styles.totalAmount}>
+              {data?.currency || 'PHP'} {data?.totalDebt.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </Text>
+            <Text variant="bodySmall" style={styles.totalLabel}>
+              Total Outstanding Debt
+            </Text>
+          </View>
+        )}
+
+        {hasDebt ? (
+          <>
+            <View style={styles.chartContainer}>
+              <BarChart
+                data={chartData}
+                width={availableWidth}
+                height={250}
+                spacing={chartSpacing}
+                initialSpacing={30}
+                endSpacing={20}
+                yAxisTextStyle={{ color: theme.colors.onSurface, fontSize: 10 }}
+                xAxisLabelTextStyle={{ color: theme.colors.onSurface, fontSize: 10 }}
+                yAxisThickness={0}
+                xAxisThickness={0}
+                xAxisColor={theme.colors.outline}
+                maxValue={data?.yAxisConfig?.maxValue}
+                stepValue={data?.yAxisConfig?.interval}
+                barBorderRadius={4}
+                isAnimated
+              />
+            </View>
+            <View style={styles.legendContainer}>
+              {legendItems.map((item) => (
+                <View key={item.category} style={styles.legendItem}>
+                  <View style={[styles.legendDot, { backgroundColor: item.color }]} />
+                  <Text variant="bodySmall" style={styles.legendLabel}>
+                    {item.category}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        ) : (
+          <View style={styles.noDataContainer}>
+            <Text variant="bodyMedium" style={styles.noDataText}>
+              No outstanding debt for this period.
+            </Text>
+          </View>
+        )}
+        <Divider style={styles.divider} />
+      </Card.Content>
+    </Card>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: customTheme.colors.surface,
+    borderRadius: customTheme.roundness,
+    marginBottom: spacing.lg,
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.xxl,
+  },
+  loadingText: {
+    marginTop: spacing.md,
+  },
+  errorText: {
+    color: customTheme.colors.error,
+    marginBottom: spacing.sm,
+  },
+  errorDetails: {
+    fontSize: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  title: {
+    fontWeight: '600',
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  titleSpinner: {
+    marginLeft: spacing.sm,
+  },
+  menuButton: {
+    margin: 0,
+  },
+  selectedMenuItem: {
+    backgroundColor: customTheme.colors.primaryContainer,
+  },
+  segmentedButtons: {
+    marginBottom: spacing.sm,
+  },
+  periodLabel: {
+    color: customTheme.colors.onSurfaceVariant,
+    marginBottom: spacing.md,
+  },
+  totalContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.lg,
+    marginBottom: spacing.md,
+  },
+  totalAmount: {
+    fontWeight: '700',
+  },
+  totalLabel: {
+    marginTop: spacing.xs,
+    color: customTheme.colors.onSurfaceVariant,
+  },
+  chartContainer: {
+    marginTop: spacing.md,
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+  },
+  legendContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginTop: spacing.sm,
+    gap: spacing.md,
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  legendDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginRight: spacing.xs,
+  },
+  legendLabel: {
+    color: customTheme.colors.onSurfaceVariant,
+  },
+  noDataContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.xxl,
+  },
+  noDataText: {
+    textAlign: 'center',
+  },
+  divider: {
+    marginVertical: spacing.lg,
+  },
+});

--- a/frontend/components/ExpenseDistributionWidget.tsx
+++ b/frontend/components/ExpenseDistributionWidget.tsx
@@ -7,7 +7,7 @@ import { useAccessContext } from '../contexts/AccessContext';
 import { useExpenseDistribution, useTopContributors } from '../hooks/useExpenseDistribution';
 import { useActiveUser } from '../hooks/useUsers';
 import { TrendPeriod } from '../types/balanceTrend';
-import { Category } from '../types/category';
+import { getCategoryColor } from '../utils/categoryColors';
 import { TopContributorsList } from './TopContributorsList';
 
 const PERIOD_OPTIONS = [
@@ -19,33 +19,6 @@ const PERIOD_OPTIONS = [
 const getPeriodLabel = (period: TrendPeriod): string => {
   const option = PERIOD_OPTIONS.find(opt => opt.value === period);
   return option?.label || 'From Start';
-};
-
-const getCategoryColor = (category: string): string => {
-  const colorMap: Record<string, string> = {
-    [Category.ALLOWANCE]: customColors.iconForegrounds.green,
-    [Category.CAR_LOAN]: customColors.iconForegrounds.purple,
-    [Category.CAR_MAINTENANCE]: customColors.iconForegrounds.gray,
-    [Category.FOOD_DRINKS]: customColors.iconForegrounds.orange,
-    [Category.FUEL]: customColors.iconForegrounds.amber,
-    [Category.GROCERIES]: customColors.iconForegrounds.cyan,
-    [Category.HEALTH_MEDICAL]: customColors.iconForegrounds.pink,
-    [Category.HOLIDAYS_EVENTS]: customColors.iconForegrounds.purple,
-    [Category.HOUSING]: customColors.iconForegrounds.blue,
-    [Category.INCIDENT_EMERGENCIES]: customColors.iconForegrounds.pink,
-    [Category.INCOME]: customColors.iconForegrounds.lightGreen,
-    [Category.LIFE_ENTERTAINMENT]: customColors.iconForegrounds.magenta,
-    [Category.OTHERS]: customColors.iconForegrounds.gray,
-    [Category.PARKING]: customColors.iconForegrounds.deepOrange,
-    [Category.PETS_ANIMALS]: customColors.iconForegrounds.amber,
-    [Category.RIDE_HAILING]: customColors.iconForegrounds.teal,
-    [Category.SHOPPING]: customColors.iconForegrounds.yellow,
-    [Category.SPORTS_FITNESS]: customColors.iconForegrounds.teal,
-    [Category.TECHNOLOGY_COMMUNICATION]: customColors.iconForegrounds.indigo,
-    [Category.TOLL]: customColors.iconForegrounds.cyan,
-  };
-
-  return colorMap[category] || customColors.iconForegrounds.gray;
 };
 
 export const ExpenseDistributionWidget: React.FC = () => {

--- a/frontend/config/api.ts
+++ b/frontend/config/api.ts
@@ -47,6 +47,16 @@ apiClient.interceptors.request.use(
     if (delegatedOwner) {
       config.headers['X-Delegated-Owner'] = delegatedOwner;
     }
+    // Every response here is scoped by the Authorization/X-Delegated-Owner
+    // headers, not by the URL - most endpoints happen to also encode owner
+    // into their query params, but some (e.g. /api/debt-trend) don't, which
+    // makes them cacheable by URL alone. Since headers aren't part of the
+    // cache key without a matching Vary response header, a browser (or the
+    // PWA's passthrough service worker) can serve one account's cached GET
+    // response back to a different signed-in/delegated account after a
+    // profile switch. Forcing no-store on every request closes that off
+    // app-wide rather than per-endpoint.
+    config.headers['Cache-Control'] = 'no-store';
     return config;
   },
   (error) => {

--- a/frontend/hooks/useDebtTrend.ts
+++ b/frontend/hooks/useDebtTrend.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDebtTrend } from '../services/debtTrend.service';
+import type { GetDebtTrendParams } from '../types/debtTrend';
+
+export const DEBT_TREND_QUERY_KEYS = {
+  all: ['debt-trend'] as const
+};
+
+interface UseDebtTrendOptions {
+  enabled?: boolean;
+}
+
+export const useDebtTrend = (
+  params: GetDebtTrendParams,
+  options: UseDebtTrendOptions = {}
+) => {
+  return useQuery({
+    queryKey: [...DEBT_TREND_QUERY_KEYS.all, params],
+    queryFn: () => getDebtTrend(params),
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    enabled: options.enabled,
+  });
+};

--- a/frontend/services/debtTrend.service.ts
+++ b/frontend/services/debtTrend.service.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '../config/api';
+import type { DebtTrendResponse, GetDebtTrendParams } from '../types/debtTrend';
+
+export const getDebtTrend = async (
+  params: GetDebtTrendParams
+): Promise<DebtTrendResponse> => {
+  const response = await apiClient.get<DebtTrendResponse>('/api/debt-trend', {
+    params: {
+      from: params.from,
+      to: params.to,
+      aggregate: params.aggregate,
+    },
+  });
+  return response.data;
+};

--- a/frontend/types/debtTrend.ts
+++ b/frontend/types/debtTrend.ts
@@ -7,8 +7,13 @@ export enum DebtAggregation {
 }
 
 export interface DebtCategoryAmount {
+  // The debt's display label - the payment's note, falling back to its
+  // category when no note is set (see backend DebtTrendService.debtLabel).
   category: string;
   amount: number;
+  // The planned payment's true category, always present, kept alongside so
+  // the UI can show it as a chip next to the note label.
+  originalCategory: string;
 }
 
 export interface DebtTrendDataPoint {
@@ -26,6 +31,10 @@ export interface DebtTrendResponse {
 }
 
 export interface GetDebtTrendParams {
+  // The backend scopes the query via the X-Delegated-Owner header, but owner
+  // must still be part of the params so the React Query cache key changes
+  // (and refetches) when the active profile switches.
+  owner: string;
   from: string;
   to: string;
   aggregate: DebtAggregation;

--- a/frontend/types/debtTrend.ts
+++ b/frontend/types/debtTrend.ts
@@ -1,0 +1,32 @@
+export { YAxisConfig } from './balanceTrend';
+import { YAxisConfig } from './balanceTrend';
+
+export enum DebtAggregation {
+  MONTHLY = 'MONTHLY',
+  YEARLY = 'YEARLY',
+}
+
+export interface DebtCategoryAmount {
+  category: string;
+  amount: number;
+}
+
+export interface DebtTrendDataPoint {
+  label: string;
+  timestamp: string;
+  totalDebt: number;
+  categories: DebtCategoryAmount[];
+}
+
+export interface DebtTrendResponse {
+  totalDebt: number;
+  currency: string;
+  dataPoints: DebtTrendDataPoint[];
+  yAxisConfig: YAxisConfig;
+}
+
+export interface GetDebtTrendParams {
+  from: string;
+  to: string;
+  aggregate: DebtAggregation;
+}

--- a/frontend/utils/categoryColors.ts
+++ b/frontend/utils/categoryColors.ts
@@ -1,0 +1,29 @@
+import { Category } from '../types/category';
+import { customColors } from '../config/theme';
+
+export const getCategoryColor = (category: string): string => {
+  const colorMap: Record<string, string> = {
+    [Category.ALLOWANCE]: customColors.iconForegrounds.green,
+    [Category.CAR_LOAN]: customColors.iconForegrounds.purple,
+    [Category.CAR_MAINTENANCE]: customColors.iconForegrounds.gray,
+    [Category.FOOD_DRINKS]: customColors.iconForegrounds.orange,
+    [Category.FUEL]: customColors.iconForegrounds.amber,
+    [Category.GROCERIES]: customColors.iconForegrounds.cyan,
+    [Category.HEALTH_MEDICAL]: customColors.iconForegrounds.pink,
+    [Category.HOLIDAYS_EVENTS]: customColors.iconForegrounds.purple,
+    [Category.HOUSING]: customColors.iconForegrounds.blue,
+    [Category.INCIDENT_EMERGENCIES]: customColors.iconForegrounds.pink,
+    [Category.INCOME]: customColors.iconForegrounds.lightGreen,
+    [Category.LIFE_ENTERTAINMENT]: customColors.iconForegrounds.magenta,
+    [Category.OTHERS]: customColors.iconForegrounds.gray,
+    [Category.PARKING]: customColors.iconForegrounds.deepOrange,
+    [Category.PETS_ANIMALS]: customColors.iconForegrounds.amber,
+    [Category.RIDE_HAILING]: customColors.iconForegrounds.teal,
+    [Category.SHOPPING]: customColors.iconForegrounds.yellow,
+    [Category.SPORTS_FITNESS]: customColors.iconForegrounds.teal,
+    [Category.TECHNOLOGY_COMMUNICATION]: customColors.iconForegrounds.indigo,
+    [Category.TOLL]: customColors.iconForegrounds.cyan,
+  };
+
+  return colorMap[category] || customColors.iconForegrounds.gray;
+};


### PR DESCRIPTION
## Summary
- Debt trend widget: stacked bar chart of outstanding debt per bucket, broken down per individual debt (grouped by the planned payment's note, falling back to category when no note is set) with a chip showing the underlying category next to each note.
- Backend now returns `originalCategory` alongside the note-derived `category` label on each `DebtCategoryAmount`, so the UI can label debts individually while still surfacing which category they belong to.
- Fixed the debt breakdown's category chip being nearly invisible (white background/transparent-outline border on a near-white panel) — now uses the app's secondary-container color pair for real contrast.
- Fixed balance trend widget showing a misleading flat PHP 0.00 line when a profile has zero transactions.
- Added a `Cache-Control: no-store` header to all API requests to stop a browser/PWA service worker from serving one account's cached GET response to a different delegated profile after a switch.

Closes #65

## Test plan
- [ ] `./gradlew test` in `backend/` (new `DebtTrendService` note-grouping tests)
- [ ] `npm run web` in `frontend/`, verify the Dashboard's Debt Trend widget: bar chart renders, tapping a segment shows the tooltip, the breakdown panel below shows one row per debt with a clearly visible category chip
- [ ] Switch delegated profile and confirm balance/debt trend/expense distribution data refreshes correctly (no stale cross-account cache)
- [ ] Confirm the Balance Trend widget hides its chart/total when a profile has no transactions instead of showing a flat PHP 0.00 line