### PR TITLE
feat(frontend): add feature flag for beta Debt Trend Widget

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,5 +1,9 @@
 API_BASE_URL=https://lazyspender-api-272563214847.us-east1.run.app
 
+# Debt Trend Widget is still in beta - kept off in production until it's stable.
+# Flip to true (or override via .env.development) to enable it.
+FEATURE_DEBT_TREND_WIDGET=false
+
 # Google Sign-In client IDs (see docs/google-sso-onboarding-design.md).
 # Web client ID is the existing backend token-verification audience.
 # Android/iOS client IDs are TBD until those OAuth clients are registered

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -7,3 +7,7 @@
 # at localhost. Everything else (Google client IDs, etc.) still comes from the tracked .env.
 # Delete or comment out to fall back to the deployed API during local dev.
 API_BASE_URL=http://localhost:8080
+
+# Debt Trend Widget stays enabled locally (off in production, see .env) so
+# development on it can continue.
+FEATURE_DEBT_TREND_WIDGET=true

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -78,7 +78,8 @@ module.exports = {
       apiBaseUrl: process.env.API_BASE_URL || "https://lazyspender-api-272563214847.us-east1.run.app",
       googleWebClientId: process.env.GOOGLE_WEB_CLIENT_ID,
       googleIosClientId: process.env.GOOGLE_IOS_CLIENT_ID,
-      googleAndroidClientId: process.env.GOOGLE_ANDROID_CLIENT_ID
+      googleAndroidClientId: process.env.GOOGLE_ANDROID_CLIENT_ID,
+      featureDebtTrendWidget: process.env.FEATURE_DEBT_TREND_WIDGET === "true"
     }
   }
 };

--- a/frontend/app/dashboard.tsx
+++ b/frontend/app/dashboard.tsx
@@ -1,6 +1,7 @@
 import { ScrollView, StyleSheet, View } from "react-native";
 import { useTheme } from "react-native-paper";
 import { spacing } from "../config/theme";
+import { featureFlags } from "../config/featureFlags";
 import { BalanceTrendWidget } from "../components/BalanceTrendWidget";
 import { DebtTrendWidget } from "../components/DebtTrendWidget";
 import { ExpenseDistributionWidget } from "../components/ExpenseDistributionWidget";
@@ -13,7 +14,7 @@ export default function Dashboard() {
       <View style={styles.content}>
         <BalanceTrendWidget />
         <ExpenseDistributionWidget />
-        <DebtTrendWidget />
+        {featureFlags.debtTrendWidget && <DebtTrendWidget />}
       </View>
     </ScrollView>
   );

--- a/frontend/config/featureFlags.ts
+++ b/frontend/config/featureFlags.ts
@@ -1,0 +1,9 @@
+import Constants from 'expo-constants';
+
+// Feature flags are sourced from FEATURE_* vars in .env / .env.development via
+// app.config.js `extra`, the same pattern used for apiBaseUrl (see config/api.ts).
+// Since they're baked in at build time, toggling one requires a rebuild/redeploy,
+// not just an env change at runtime.
+export const featureFlags = {
+  debtTrendWidget: Constants.expoConfig?.extra?.featureDebtTrendWidget === true,
+};


### PR DESCRIPTION
## Summary
- Adds `FEATURE_DEBT_TREND_WIDGET` env-backed feature flag, following the existing `app.config.js` `extra` + `expo-constants` pattern used for `apiBaseUrl`/Google client IDs
- Defaults **off** in production (`frontend/.env`), **on** in local dev (`frontend/.env.development`) so work on the widget can continue
- `dashboard.tsx` now gates `<DebtTrendWidget />` behind `featureFlags.debtTrendWidget`

Closes #94

## Test plan
- [ ] `npm run web` locally with default `.env.development` — widget renders (flag on)
- [ ] Set `FEATURE_DEBT_TREND_WIDGET=false` in `.env.development` (or unset it) and confirm the widget is hidden, rest of dashboard renders normally
- [ ] Confirm production `.env` ships with the flag off so the widget stays hidden until explicitly enabled